### PR TITLE
Fix corrupt string that contain non-ASCII characters

### DIFF
--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorNote.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorNote.java
@@ -72,7 +72,8 @@ public class AnsiColorNote extends ConsoleNote {
     public static String colorize(String data) throws IOException {
     	ByteArrayOutputStream out = new ByteArrayOutputStream();
 		AnsiColorizer colorizer = new AnsiColorizer(out, Charset.defaultCharset());
-		colorizer.eol(data.getBytes(), data.length());
+		byte[] bytes = data.getBytes();
+		colorizer.eol(bytes, bytes.length);
 		return out.toString();
     }
 

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorizerTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorizerTest.java
@@ -84,6 +84,11 @@ public class AnsiColorizerTest {
 		assertThat(colorize(">"), is("&gt;"));
 	}
 
+	@Test
+	public void testUTF8Character() throws IOException {
+		assertThat(colorize("[1m\u3053\u3093\u306b\u3061\u306f"), is("<b>\u3053\u3093\u306b\u3061\u306f</b>"));
+	}
+
 	private String colorize(String text) throws IOException {
 		return AnsiColorNote.colorize(text);
 	}


### PR DESCRIPTION
The data is corrupt when it contains multi-byte character since String#length() returns num of characters.
