### PR TITLE
suspend tags at end of every output chunk to work around IE workaround

### DIFF
--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
@@ -110,6 +110,14 @@ public final class AnsiColorBuildWrapper extends BuildWrapper {
             }
 
             @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                // See the comments to those methods on why this is needed.
+                ansi.resumeTags();
+                super.write(b, off, len);
+                ansi.suspendTags();
+            }
+
+            @Override
             public void close() throws IOException {
                 ansi.close();
                 logger.close();

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -160,9 +160,9 @@ public class AnsiHtmlOutputStreamTest {
     public void testDefaultColors() throws IOException {
         assertThat(
                 annotate("\033[32mtic\033[1mtac\033[39mtoe", AnsiColorMap.VGA),
-                is("<div style=\"background-color: #000000;color: #AAAAAA;\">" +
+                is("<span style=\"display: block;background-color: #000000;color: #AAAAAA;\">" +
                         "<span style=\"color: #00AA00;\">tic<b>tac</b></span><b>toe</b>" +
-                        "</div>"));
+                        "</span>"));
     }
 
 


### PR DESCRIPTION
This closes and reopens the elements for every output chunk, effectively getting rid of the problem incurred by Jenkins' IE workaround.
