### PR TITLE
Filter out escape sequence 'character set' select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 0.5.2 (Next)
 ============
 
+* [#111](https://github.com/jenkinsci/ansicolor-plugin/pull/111): Filter out escape sequence 'character set' select - [@pmhahn](https://github.com/pmhahn).
 * Your contribution here.
 
 0.5.1 (08/10/2017)
-============
+==================
 
 * [#100](https://github.com/jenkinsci/ansicolor-plugin/pull/100): Migrated hosting to github.com/jenkinsci - [@JoeMerten](https://github.com/JoeMerten) & [@dblock](https://github.com/dblock).
 * [#101](https://github.com/jenkinsci/ansicolor-plugin/pull/101): Some exceptions during plugin install and following jenkins start - [@JoeMerten](https://github.com/JoeMerten).

--- a/src/main/java/hudson/plugins/ansicolor/AnsiOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiOutputStream.java
@@ -63,6 +63,7 @@ public class AnsiOutputStream extends FilterOutputStream {
     private static final int LOOKING_FOR_OSC_COMMAND_END = 6;
     private static final int LOOKING_FOR_OSC_PARAM = 7;
     private static final int LOOKING_FOR_ST = 8;
+    private static final int LOOKING_FOR_CHARSET = 9;
 
     int state = LOOKING_FOR_FIRST_ESC_CHAR;
 
@@ -71,6 +72,8 @@ public class AnsiOutputStream extends FilterOutputStream {
     private static final int SECOND_OSC_CHAR = ']';
     private static final int BEL = 7;
     private static final int SECOND_ST_CHAR = '\\';
+    private static final int SECOND_CHARSET0_CHAR = '(';
+    private static final int SECOND_CHARSET1_CHAR = ')';
 
     // TODO: implement to get perf boost: public void write(byte[] b, int off, int len)
 
@@ -91,6 +94,12 @@ public class AnsiOutputStream extends FilterOutputStream {
                     state = LOOKING_FOR_NEXT_ARG;
                 } else if (data == SECOND_OSC_CHAR) {
                     state = LOOKING_FOR_OSC_COMMAND;
+                } else if (data == SECOND_CHARSET0_CHAR) {
+                    options.add(new Integer('0'));
+                    state = LOOKING_FOR_CHARSET;
+                } else if (data == SECOND_CHARSET1_CHAR) {
+                    options.add(new Integer('1'));
+                    state = LOOKING_FOR_CHARSET;
                 } else {
                     reset(false);
                 }
@@ -192,6 +201,11 @@ public class AnsiOutputStream extends FilterOutputStream {
                 } else {
                     state = LOOKING_FOR_OSC_PARAM;
                 }
+                break;
+
+            case LOOKING_FOR_CHARSET:
+                options.add(new Character((char) data));
+                reset(processCharsetSelect(options));
                 break;
         }
 
@@ -543,6 +557,21 @@ public class AnsiOutputStream extends FilterOutputStream {
     }
 
     protected void processUnknownOperatingSystemCommand(int command, String param) {
+    }
+
+    /**
+     * Process character set sequence.
+     * @param options
+     * @return true if the charcter set select command was processed.
+     */
+    private boolean processCharsetSelect(ArrayList<Object> options) throws IOException {
+        int set = optionInt(options, 0);
+        char seq = ((Character) options.get(1)).charValue();
+        processCharsetSelect(set, seq);
+        return true;
+    }
+
+    protected void processCharsetSelect(int set, char seq) {
     }
 
     private int optionInt(ArrayList<Object> options, int index) {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -591,6 +591,12 @@ public class AnsiHtmlOutputStreamTest {
         );
     }
 
+    @Test
+    public void testResetCharacterSet() throws IOException {
+        assertThatAnnotateIs("(\033(0)", "()");
+        assertThatAnnotateIs("(\033)0)", "()");
+    }
+
     private void assertThatAnnotateIs(String ansi, String html) throws IOException {
         assertThat(annotate(ansi), is(html));
     }


### PR DESCRIPTION
Some terminals (xterm) supports two different 'character sets' ('G0' and
'G1'), which can be switched with 'SI' (shift in, '\017') and 'SO'
(shift out, '\016'). Each character set can be configured separately
and can be chosen from a list of pre-defined sets like 'ASCII Set' and
'Special Graphics'.

Running `TERM=xterm tput sgr0` to reset the terminal returns an escape
sequence starting with 'ESC ( 0', which selects the 'ASCII Set' for
'G0'. This currently is not understood by the Jenkins AnsiColor plugin.

Filter out those sequences, as they otherwise clutter the output.

<https://www.in-ulm.de/~mascheck/various/alternate_charset/> has a nice
description for characters sets