### PR TITLE
Ignore unknown SGR (Select Graphic Rendition) parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * [#111](https://github.com/jenkinsci/ansicolor-plugin/pull/111): Filter out escape sequence 'character set' select - [@pmhahn](https://github.com/pmhahn).
+* [#112](https://github.com/jenkinsci/ansicolor-plugin/pull/112): Filter out 'font select' escape sequence - [@pmhahn](https://github.com/pmhahn).
 * Your contribution here.
 
 0.5.1 (08/10/2017)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -357,7 +357,7 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
     }
 
     // add attribute constants which are currently missing in jansi
-    // see also https://en.wikipedia.org/wiki/ANSI_escape_code
+    // see also <https://en.wikipedia.org/wiki/ANSI_escape_code#graphics>
     protected static final int ATTRIBUTE_STRIKEOUT       =  9;
     protected static final int ATTRIBUTE_ITALIC_OFF      = 23;
     protected static final int ATTRIBUTE_STRIKEOUT_OFF   = 29;
@@ -375,6 +375,9 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         // See also: https://github.com/jenkinsci/ansicolor-plugin/issues/91
         if (attribute >= 90 && attribute <= 97) {
             processSetForegroundColor(attribute - 90, true);
+        }
+        else if (attribute >= 10 && attribute <= 19) {
+            // Select Primary(Default) / n-th alternate font
         }
         else if (attribute >= 100 && attribute <= 107) {
             processSetBackgroundColor(attribute - 100, true);
@@ -466,7 +469,7 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
             closeTagOfType(AnsiAttrType.OVERLINE);
             break;
         default:
-            throw new IllegalStateException("Attribute " + attribute + " should not be reached");
+            break;
         }
     }
 

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -597,6 +597,11 @@ public class AnsiHtmlOutputStreamTest {
         assertThatAnnotateIs("(\033)0)", "()");
     }
 
+    @Test
+    public void testFontDefault() throws IOException {
+        assertThatAnnotateIs("(\033[10m)", "()");
+    }
+
     private void assertThatAnnotateIs(String ansi, String html) throws IOException {
         assertThat(annotate(ansi), is(html));
     }


### PR DESCRIPTION
like select primary/n-th alternate font

Fixes #112

Quick test:

    printf '\033[10m\n'