### PR TITLE
add helper method to create AnsiHtmlOutputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * Your contribution here.
+* [#119](https://github.com/jenkinsci/ansicolor-plugin/pull/119): Add helper method to create AnsiHtmlOutputStream - [@jstrachan](https://github.com/jstrachan).
 * [#107](https://github.com/jenkinsci/ansicolor-plugin/pull/107): Removing startup banner - [@jglick](https://github.com/jglick).
 
 0.5.2 (08/17/2017)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
@@ -7,7 +7,6 @@ import hudson.model.AbstractBuild;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -35,16 +34,7 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
         }
 
         return new LineTransformationOutputStream() {
-            AnsiHtmlOutputStream ansi = new AnsiHtmlOutputStream(logger, colorMap, new AnsiAttributeElement.Emitter() {
-                @Override
-                public void emitHtml(String html) {
-                    try {
-                        new SimpleHtmlNote(html).encodeTo(logger);
-                    } catch (IOException e) {
-                        LOG.log(Level.WARNING, "Failed to add HTML markup '" + html + "'", e);
-                    }
-                }
-            });
+            AnsiHtmlOutputStream ansi = AnsiHtmlOutputStream.createJenkinsAnsiHtmlOutputStream(logger, colorMap);
 
             @Override
             protected void eol(byte[] b, int len) throws IOException {
@@ -61,4 +51,5 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
             }
         };
     }
+
 }


### PR DESCRIPTION
minor refactor to make it easier to create new AnsiHtmlOutputStream objects
to wrap an OutputStream for easier reuse of the ansicolor plugin in other jenkins plugins

e.g. I wanted to be able to wrap an OutputStream easily with an AnsiHtmlOutputStream inside the [updatebot plugin](https://github.com/jenkinsci/updatebot-plugin) but couldn't as the emitter stuff is not public.

So adding this reusable public static helper method makes it easier to reuse