### PR TITLE
Use Java 8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
-
+jdk:
+  - oraclejdk8
 matrix:
   include:
     - os: linux
     - os: osx
-      env: JAVA_HOME=$(/usr/libexec/java_home)
+      osx_image: xcode9.3


### PR DESCRIPTION
This fixes the current build issue on Travis for Linux.

Currently Java 10 is the default on Travis but the project does not yet compile with Java 10. Specifying the desired JDK version is anyway a good idea.

The OSX build can also be fixed. But I would suggest to remove testing on OSX completely. I haven't seen it for other plugins. A plugin is anyway build centrally and provided in binary form. So testing the build on another platform doesn't really provide that much.

Another question is if the plugin should better be build using the Jenkins infrastructure - see https://github.com/jenkins-infra/pipeline-library and https://ci.jenkins.io/job/Plugins/.

Therefore I propose to replace the `.travis.yml` with `Jenkinsfile`.