### PR TITLE
[JENKINS-54133] Pregenerating console notes sent to agents for some common cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Your contribution here.
 * [#107](https://github.com/jenkinsci/ansicolor-plugin/pull/107): Removing startup banner - [@jglick](https://github.com/jglick).
+* [#128](https://github.com/jenkinsci/ansicolor-plugin/pull/128): Restoring limited compatibility for coloration generated remotely by Pipeline builds on agents - [@jglick](https://github.com/jglick).
 
 0.5.2 (08/17/2017)
 ============

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.25</version>
+    <version>3.25</version>
+    <relativePath />
   </parent>
 
   <artifactId>ansicolor</artifactId>
@@ -45,23 +46,51 @@
   </distributionManagement>
 
   <properties>
-    <jenkins.version>1.642.3</jenkins.version>
+    <jenkins.version>2.121.2</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <dependencies>
     <dependency>
      <groupId>org.jenkins-ci.plugins.workflow</groupId>
      <artifactId>workflow-step-api</artifactId>
-     <version>2.12</version>
+     <version>2.15</version>
      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-aggregator</artifactId>
-      <version>2.5</version>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>2.25</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>2.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>structs</artifactId>
+        <version>1.17</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <repositories>
     <repository>

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
@@ -3,12 +3,16 @@ package hudson.plugins.ansicolor;
 import hudson.console.ConsoleLogFilter;
 import hudson.console.LineTransformationOutputStream;
 import hudson.model.AbstractBuild;
+import java.io.ByteArrayOutputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.JenkinsJVM;
 
 /**
  * {@link ConsoleLogFilter} that adds a {@link SimpleHtmlNote} to each line.
@@ -20,10 +24,40 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
     private static final Logger LOG = Logger.getLogger(AnsiColorConsoleLogFilter.class.getName());
 
     private AnsiColorMap colorMap;
+    private final Map<String, byte[]> notes;
 
     public AnsiColorConsoleLogFilter(AnsiColorMap colorMap) {
         super();
         this.colorMap = colorMap;
+        this.notes = new HashMap<>();
+        // some cases of AnsiHtmlOutputStream.setForegroundColor:
+        for (AnsiColorMap.Color color : AnsiColorMap.Color.values()) {
+            pregenerateNote(new AnsiAttributeElement(AnsiAttributeElement.AnsiAttrType.FG, "span", "style=\"color: " + colorMap.getNormal(color.ordinal()) + ";\""));
+        }
+        // TODO other cases, and other methods
+        LOG.log(Level.FINE, "Notes pregenerated for {0}", notes.keySet());
+    }
+    
+    private void pregenerateNote(AnsiAttributeElement element) {
+        element.emitOpen(html -> pregenerateNote(html));
+        element.emitClose(html -> pregenerateNote(html));
+    }
+    
+    private void pregenerateNote(String html) {
+        if (!notes.containsKey(html)) {
+            JenkinsJVM.checkJenkinsJVM();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try {
+                new SimpleHtmlNote(html).encodeTo(baos);
+            } catch (IOException x) { // should be impossible
+                throw new RuntimeException(x);
+            }
+            notes.put(html, baos.toByteArray());
+        }
+    }
+
+    private Object readResolve() { // handle old program.dat
+        return notes == null ? new AnsiColorConsoleLogFilter(colorMap) : this;
     }
 
     @SuppressWarnings("rawtypes")
@@ -39,7 +73,12 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
                 @Override
                 public void emitHtml(String html) {
                     try {
-                        new SimpleHtmlNote(html).encodeTo(logger);
+                        byte[] pregenerated = notes.get(html);
+                        if (pregenerated != null) {
+                            logger.write(pregenerated);
+                        } else {
+                            new SimpleHtmlNote(html).encodeTo(logger);
+                        }
                     } catch (IOException e) {
                         LOG.log(Level.WARNING, "Failed to add HTML markup '" + html + "'", e);
                     }

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -1,11 +1,12 @@
 package hudson.plugins.ansicolor;
 
 import hudson.Functions;
+import hudson.console.ConsoleNote;
 import java.io.StringWriter;
+import java.util.logging.Level;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Assume;
@@ -13,6 +14,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class AnsiColorBuildWrapperTest {
@@ -42,7 +45,10 @@ public class AnsiColorBuildWrapperTest {
     public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule
     public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule
+    public LoggerRule logging = new LoggerRule().recordPackage(ConsoleNote.class, Level.FINE);
 
+    @Issue("JENKINS-54133")
     @Test
     public void testWorkflowWrap() throws Exception {
         story.addStep(new Statement() {
@@ -50,9 +56,10 @@ public class AnsiColorBuildWrapperTest {
             @Override
             public void evaluate() throws Throwable {
                 Assume.assumeTrue(!Functions.isWindows());
+                story.j.createSlave();
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
-                        "node {\n"
+                        "node('!master') {\n"
                         + "  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 1, 'defaultBg': 2]) {\n"
                         + "    sh(\"\"\"#!/bin/bash\n"
                         + "      printf 'The following word is supposed to be \\\\e[31mred\\\\e[0m\\\\n'\"\"\"\n"


### PR DESCRIPTION
[JENKINS-54133](https://issues.jenkins-ci.org/browse/JENKINS-54133). Does not attempt to pregenerate notes for all cases, and in fact this seems to be impossible, though more common cases could certainly be added as needed.

As noted in JIRA, reimplementing the plugin as a `ConsoleAnnotatorFactory` would be a better solution in many respects, as well as fully solving this issue, but this would be a more ambitious refactoring than I am prepared to take on at the moment as it would involve inverting the control flow of `AnsiOutputStream`. See the corresponding Blue Ocean https://github.com/jenkinsci/blueocean-plugin/pull/1325 for a very general idea.