### PR TITLE
Remove explicit distributionManagement setting in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,6 @@
     <url>http://github.com/jenkinsci/ansicolor-plugin</url>
     <tag>HEAD</tag>
   </scm>
-  <distributionManagement>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/releases/</url>
-    </repository>
-  </distributionManagement>
 
   <properties>
     <jenkins.version>2.121.2</jenkins.version>


### PR DESCRIPTION
The [parent pom already defines a repository with the same URL with the id `maven.jenkins-ci.org`](https://github.com/jenkinsci/plugin-pom/blob/1f691cf5dd69b5626716c6b1564f2d67d8f8af34/pom.xml#L808-L818). My local `~/.m2/settings.xml` specifies a password for this repo using that id, but this plugin overrides the id for the repository, which means that my local settings were ignored, so I was unable to publish my changes to Artifactory until @jglick pointed out what was going on.

I think it is better to be consistent with other plugins and remove the override here, but anyone releasing the plugin may need to change their local settings.xml after this change.

