### PR TITLE
Allow escape sequences to span multiple lines and support default fg/bg colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * Your contribution here.
+* [#137](https://github.com/jenkinsci/ansicolor-plugin/pull/137): Allow escape sequences to span multiple lines and support color maps that set default background/foreground colors - [@dwnusbaum](https://github.com/dwnusbaum).
 
 0.6.1 (01/04/2019)
 ============

--- a/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
@@ -65,6 +65,11 @@ class AnsiAttributeElement {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "<" + name + " " + attributes + ">";
+    }
+
     public static AnsiAttributeElement bold() {
         return new AnsiAttributeElement(AnsiAttributeElement.AnsiAttrType.BOLD, "b", "");
     }

--- a/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
@@ -67,7 +67,7 @@ class AnsiAttributeElement {
 
     @Override
     public String toString() {
-        return "<" + name + " " + attributes + ">";
+        return "AnsiAttributeElement{ansiAttrType=" + ansiAttrType + ",name=" + name + ",attributes=" + attributes + "}";
     }
 
     public static AnsiAttributeElement bold() {

--- a/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
@@ -1,5 +1,7 @@
 package hudson.plugins.ansicolor;
 
+import java.io.Serializable;
+
 /**
  * Represents an HTML elements which maps to an ANSI attribute.
  *
@@ -12,7 +14,9 @@ package hudson.plugins.ansicolor;
  * other software or testing the HTML may be emitted otherwise.
  */
 
-class AnsiAttributeElement {
+class AnsiAttributeElement implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public static enum AnsiAttrType {
         DEFAULT, BOLD, ITALIC, UNDERLINE, STRIKEOUT, FRAMED, OVERLINE, FG, BG, FGBG
     }

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -30,6 +30,7 @@ import hudson.util.NullStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Stack;
 
 /**
@@ -93,12 +94,19 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         this.out = logOutput;
     }
 
-    private void openTag(AnsiAttributeElement tag) throws IOException {
+    /**
+     * @return A copy of the {@link AnsiAttributeElement}s which are currently opened, in order from outermost to innermost tag.
+     */
+    /*package*/ List<AnsiAttributeElement> getOpenTags() {
+        return new ArrayList<>(openTags);
+    }
+
+    /*package*/ void openTag(AnsiAttributeElement tag) throws IOException {
         openTags.add(tag);
         tag.emitOpen(emitter);
     }
 
-    private void closeOpenTags(AnsiAttrType until) throws IOException {
+    /*package*/ void closeOpenTags(AnsiAttrType until) throws IOException {
         while (!openTags.isEmpty()) {
             int index = openTags.size() - 1;
             if (until != null && openTags.get(index).ansiAttrType == until)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -106,7 +106,7 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         tag.emitOpen(emitter);
     }
 
-    /*package*/ void closeOpenTags(AnsiAttrType until) throws IOException {
+    private void closeOpenTags(AnsiAttrType until) throws IOException {
         while (!openTags.isEmpty()) {
             int index = openTags.size() - 1;
             if (until != null && openTags.get(index).ansiAttrType == until)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -30,8 +30,10 @@ import hudson.util.NullStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
+import javax.annotation.Nonnull;
 
 /**
  * Filters an outputstream of ANSI escape sequences and emits appropriate HTML elements instead.
@@ -60,16 +62,27 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
     private boolean swapColors = false;  // true if negative / inverse mode is active (esc[7m)
 
     // A Deque might be a better choice, but we are constrained by the Java 5 API.
-    private ArrayList<AnsiAttributeElement> openTags = new ArrayList<AnsiAttributeElement>();
+    private ArrayList<AnsiAttributeElement> openTags;
 
     private OutputStream logOutput;
 
-    public AnsiHtmlOutputStream(final OutputStream os, final AnsiColorMap colorMap,
-        final AnsiAttributeElement.Emitter emitter) {
+    /**
+     * @param tagsToOpen A list of tags to open in the given order immediately after opening the tag for the default
+     * foreground/background colors (if such colors are specified by the color map) before any data is written to the
+     * underlying stream.
+     */
+    /*package*/ AnsiHtmlOutputStream(final OutputStream os, final AnsiColorMap colorMap,
+        final AnsiAttributeElement.Emitter emitter, @Nonnull List<AnsiAttributeElement> tagsToOpen) {
         super(os);
         this.logOutput = os;
         this.colorMap = colorMap;
         this.emitter = emitter;
+        this.openTags = new ArrayList<>(tagsToOpen);
+    }
+
+    public AnsiHtmlOutputStream(final OutputStream os, final AnsiColorMap colorMap,
+        final AnsiAttributeElement.Emitter emitter) {
+        this(os, colorMap, emitter, Collections.emptyList());
     }
 
     // Debug output for plugin developers. Puts the debug message into the html page
@@ -101,7 +114,7 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         return new ArrayList<>(openTags);
     }
 
-    /*package*/ void openTag(AnsiAttributeElement tag) throws IOException {
+    private void openTag(AnsiAttributeElement tag) throws IOException {
         openTags.add(tag);
         tag.emitOpen(emitter);
     }
@@ -206,6 +219,9 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         // the preamble is an ANSI escape sequence itself.
 
         if (state == State.INIT) {
+            List<AnsiAttributeElement> tagsToOpen = new ArrayList<>(openTags);
+            openTags.clear();
+
             Integer defaultFg = colorMap.getDefaultForeground();
             Integer defaultBg = colorMap.getDefaultBackground();
 
@@ -213,6 +229,10 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
                 openTag(new AnsiAttributeElement(AnsiAttrType.DEFAULT, "div", "style=\"" +
                         (defaultBg != null ? "background-color: " + colorMap.getNormal(defaultBg) + ";" : "") +
                         (defaultFg != null ? "color: " + colorMap.getNormal(defaultFg) + ";" : "") + "\""));
+            }
+
+            for (AnsiAttributeElement tag : tagsToOpen) {
+                openTag(tag);
             }
 
             state = State.DATA;

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -145,15 +145,6 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                 : new ColorConsoleAnnotator(colorMapName, nextOpenTags);
     }
 
-    private Object readResolve() {
-        // Compatibility for instances serialized before the openTags field was added.
-        if (openTags == null) {
-            return new ColorConsoleAnnotator(colorMapName);
-        } else {
-            return this;
-        }
-    }
-
     @Extension
     public static final class Factory extends ConsoleAnnotatorFactory<Object> {
 

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -58,7 +58,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
     ColorConsoleAnnotator(String colorMapName, List<AnsiAttributeElement> openTags) {
         this.colorMapName = colorMapName;
         this.openTags = openTags;
-        LOGGER.log(Level.FINE, "creating annotator with colorMapName={0} openTags={2}", new Object[] { colorMapName, openTags });
+        LOGGER.log(Level.FINE, "creating annotator with colorMapName={0} openTags={1}", new Object[] { colorMapName, openTags });
     }
 
     ColorConsoleAnnotator(String colorMapName) {
@@ -69,8 +69,6 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
     public ConsoleAnnotator<Object> annotate(Object context, MarkupText text) {
         String s = text.getText();
         List<AnsiAttributeElement> nextOpenTags = openTags;
-        // TODO: As a performance improvement, we could create a branch where `s.indexOf('\u001B') == -1` but other
-        // conditions are true that surrounds the text in the appropriate tags without going through AnsiHtmlOutputStream.
         AnsiColorMap colorMap = Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).getColorMap(colorMapName);
         if (s.indexOf('\u001B') != -1 || !openTags.isEmpty() || colorMap.getDefaultBackground() != null || colorMap.getDefaultForeground() != null) {
             CountingOutputStream outgoing = new CountingOutputStream(new NullOutputStream());
@@ -132,6 +130,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                 if (colorMap.getDefaultBackground() != null || colorMap.getDefaultForeground() != null) {
                     // The default color scheme will be opened automatically at the beginning of the stream on the next
                     // line, so we don't want to duplicate it.
+                    // AnsiHtmlOutputStream#getOpenTags makes a copy so calling `remove` is safe.
                     nextOpenTags.remove(0);
                 }
                 // Tags open at the end of the line are closed when the stream is closed by the try-with-resources block.

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -105,9 +105,6 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                         }
                     }
                 }
-                public void emitHtmlDirect(String html) {
-                    text.addMarkup(incoming.getCount(), html);
-                }
             }
             EmitterImpl emitter = new EmitterImpl();
             // We need to reopen tags that were still open at the end of the previous line so the stream's state is

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -171,4 +171,26 @@ public class AnsiColorBuildWrapperTest {
             }
         });
     }
+
+    @Test
+    public void testNonAscii() throws Exception {
+        story.then(r -> {
+            FreeStyleProject p = r.createFreeStyleProject();
+            p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
+            p.getBuildersList().add(new TestBuilder() {
+                @Override
+                public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                    listener.getLogger().println("\033[94;1m[ INFO ] Récupération du numéro de version de l'application\033[0m");
+                    return true;
+                }
+            });
+            FreeStyleBuild b = r.buildAndAssertSuccess(p);
+            StringWriter writer = new StringWriter();
+            b.getLogText().writeHtmlTo(0L, writer);
+            String html = writer.toString();
+            System.out.print(html);
+            assertThat(html.replaceAll("<span style=\"display: none\">.+?</span>", ""),
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] Récupération du numéro de version de l'application</b></span>"));
+        });
+    }
 }

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Assume;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -90,7 +89,6 @@ public class AnsiColorBuildWrapperTest {
     }
 
     @Test
-    @Ignore
     public void testMultilineEscapeSequence() throws Exception {
         story.then(r -> {
             FreeStyleProject p = r.createFreeStyleProject();
@@ -99,6 +97,7 @@ public class AnsiColorBuildWrapperTest {
                 @Override
                 public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                     listener.getLogger().println("\u001B[1;34mThis text should be bold and blue");
+                    listener.getLogger().println("Still bold and blue");
                     listener.getLogger().println("\u001B[mThis text should be normal");
                     return true;
                 }
@@ -110,9 +109,8 @@ public class AnsiColorBuildWrapperTest {
             System.out.print(html);
             assertThat(html.replaceAll("<span style=\"display: none\">.+?</span>", ""),
                 allOf(
-                    // <b> and <span> are never closed.
-                    containsString("<b><span style=\"color: #1E90FF;\">This text should be bold and blue</span></b>"),
-                    // This should be inside of a span with `display: none`, but it is not.
+                    containsString("<b><span style=\"color: #1E90FF;\">This text should be bold and blue\n</span></b>"),
+                    containsString("<b><span style=\"color: #1E90FF;\">Still bold and blue\n</span></b>"),
                     not(containsString("\u001B[m"))));
         });
     }

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -181,6 +181,7 @@ public class AnsiColorBuildWrapperTest {
                 @Override
                 public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                     listener.getLogger().println("\033[94;1m[ INFO ] Récupération du numéro de version de l'application\033[0m");
+                    listener.getLogger().println("\033[94;1m[ INFO ] ビルドのコンソール出力を取得します。\033[0m");
                     return true;
                 }
             });
@@ -190,7 +191,9 @@ public class AnsiColorBuildWrapperTest {
             String html = writer.toString();
             System.out.print(html);
             assertThat(html.replaceAll("<!--.+?-->", ""),
-                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] Récupération du numéro de version de l'application</b></span>"));
+                allOf(
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] Récupération du numéro de version de l'application</b></span>"),
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] ビルドのコンソール出力を取得します。</b></span>")));
         });
     }
 }


### PR DESCRIPTION
Fixes #135.
 
This PR currently adds tests and fixes for 2 issues:

1. If an escape sequence is not closed at the end of a line, its tag cannot be closed and its style modifications will carry over to all subsequent lines.
    * This PR currently closes all tags that are open at the end of a line and then reopens them on the next line so that ANSI sequences in the line can close those tags correctly. I am not sure whether this is the desired behavior, or if we should instead close any tags that are open at the end of a line and leave them closed for good.
2. When using a color map with a default foreground or background, the default foreground and background are not used.
    * This PR handles default foreground and background settings. I am not sure how often default foreground/background colors are used, so maybe we don't care about this, but it was easy enough to add support for it. 
