### PR TITLE
Use <!--…--> rather than <span style="display: none">…</span> for processed escape sequences

### DIFF
--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -76,7 +76,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                         lastPoint = incoming.getCount();
                         int hide = incoming.getCount() - outgoing.getCount() - adjustment;
                         LOGGER.finest("hiding " + hide + " @" + (outgoing.getCount() + adjustment));
-                        text.addMarkup(outgoing.getCount() + adjustment, outgoing.getCount() + adjustment + hide, "<span style=\"display: none\">", "</span>");
+                        text.addMarkup(outgoing.getCount() + adjustment, outgoing.getCount() + adjustment + hide, "<!--", "-->");
                         adjustment += hide;
                     }
                 }

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -81,7 +81,7 @@ public class AnsiColorBuildWrapperTest {
             b.getLogText().writeHtmlTo(0L, writer);
             String html = writer.toString();
             System.out.print(html);
-            assertThat(html.replaceAll("<span style=\"display: none\">.+?</span>", ""),
+            assertThat(html.replaceAll("<!--.+?-->", ""),
                 allOf(
                     containsString("[<b><span style=\"color: #1E90FF;\">INFO</span></b>]"),
                     containsString("<b>--------------&lt; </b><span style=\"color: #00CDCD;\">org.jenkins-ci.plugins:build-token-root</span><b> &gt;---------------</b>")));
@@ -112,7 +112,7 @@ public class AnsiColorBuildWrapperTest {
                 p.getLastBuild().getLogText().writeHtmlTo(0L, writer);
                 String html = writer.toString();
                 assertTrue("Failed to match color attribute in following HTML log output:\n" + html,
-                    html.replaceAll("<span style=\"display: none\">.+?</span>", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
+                    html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
             }
         });
     }

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
@@ -60,7 +60,7 @@ public class AnsiColorStepTest {
                 String html = writer.toString();
                 story.j.assertLogContains("TERM=xterm", run);
                 assertTrue("Failed to match color attribute in following HTML log output:\n" + html,
-                        html.replaceAll("<span style=\"display: none\">.+?</span>", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
+                        html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
             }
         });
     }


### PR DESCRIPTION
Inspired by a comment by @sophistifunk in [JENKINS-41200](https://issues.jenkins-ci.org/browse/JENKINS-41200).