### PR TITLE
Fix #139: Handle non-ASCII characters correctly when annotating text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * Your contribution here.
+* [#139](https://github.com/jenkinsci/ansicolor-plugin/issues/139)/[#143](https://github.com/jenkinsci/ansicolor-plugin/pull/143): Prevent an `IndexOutOfBoundsException` from being thrown when two or more non-ASCII-compatible characters are present in colored text - [@dwnusbaum](https://github.com/dwnusbaum).
 
 0.6.0 (11/14/2018)
 ============

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -87,9 +87,10 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                  * We only use AnsiHtmlOutputStream for its calls to Emitter.emitHtml when it encounters ANSI escape
                  * sequences; the output of the stream will be discarded. To know where to insert HTML in the MarkupText,
                  * we track the number of bytes we have written, and use that as a char (UTF-16 code unit) offset into
-                 * the original String. Since all ANSI escape sequences can be represented in ASCII using a single byte,
-                 * and ASCII characters are represented in UTF-16BE using just the lower byte, we write all ASCII chars
-                 * to the stream unmodified, and convert any other character into '?' as a placeholder so the number of
+                 * the original String. Since all ANSI escape sequences only use ASCII characters, and ASCII characters
+                 * in UTF-16BE are all represented using a single code unit whose high byte is 0, and whose low byte is
+                 * the same as it would be in an 8-bit ASCII encoding, we write all ASCII chars to the stream as the low
+                 * byte of the code unit, and convert any other character into '?' as a placeholder so the number of
                  * bytes written matches the char offset into the String.
                  */
                 for (int i = 0; i < s.length(); i++) {

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -92,6 +92,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                  */
                 byte[] data = s.getBytes("US-ASCII");
                 for (int i = 0; i < data.length; i++) {
+                    // Do not use write(byte[]) as offsets in incoming would not be accurate.
                     incoming.write(data[i]);
                 }
             } catch (IOException x) {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -127,6 +127,8 @@ public class AnsiColorBuildWrapperTest {
                 public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                     listener.getLogger().println("\033[94;1m[ INFO ] Récupération du numéro de version de l'application\033[0m");
                     listener.getLogger().println("\033[94;1m[ INFO ] ビルドのコンソール出力を取得します。\033[0m");
+                     // There are 3 smiley face emojis in this String
+                    listener.getLogger().println("\033[94;1m[ INFO ] 😀😀\033[0m😀");
                     return true;
                 }
             });
@@ -138,7 +140,8 @@ public class AnsiColorBuildWrapperTest {
             assertThat(html.replaceAll("<!--.+?-->", ""),
                 allOf(
                     containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] Récupération du numéro de version de l'application</b></span>"),
-                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] ビルドのコンソール出力を取得します。</b></span>")));
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] ビルドのコンソール出力を取得します。</b></span>"),
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] 😀😀</b></span>😀")));
         });
     }
 }

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -116,4 +116,29 @@ public class AnsiColorBuildWrapperTest {
             }
         });
     }
+
+    @Test
+    public void testNonAscii() throws Exception {
+        story.then(r -> {
+            FreeStyleProject p = r.createFreeStyleProject();
+            p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
+            p.getBuildersList().add(new TestBuilder() {
+                @Override
+                public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                    listener.getLogger().println("\033[94;1m[ INFO ] Récupération du numéro de version de l'application\033[0m");
+                    listener.getLogger().println("\033[94;1m[ INFO ] ビルドのコンソール出力を取得します。\033[0m");
+                    return true;
+                }
+            });
+            FreeStyleBuild b = r.buildAndAssertSuccess(p);
+            StringWriter writer = new StringWriter();
+            b.getLogText().writeHtmlTo(0L, writer);
+            String html = writer.toString();
+            System.out.print(html);
+            assertThat(html.replaceAll("<!--.+?-->", ""),
+                allOf(
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] Récupération du numéro de version de l'application</b></span>"),
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] ビルドのコンソール出力を取得します。</b></span>")));
+        });
+    }
 }


### PR DESCRIPTION
Fixes #139.

The cause of the issue is that we were using byte indices as `String` indices, which does not work when the `String` contains characters that require than one byte in the target encoding. To fix the issue, this PR keeps track of the number of multi-byte characters we've seen and how many bytes they require, and uses that information to convert the byte count obtained from `incoming.getCount()` into an index into the original text.

I originally worked on this in #137 but extracted it here so it can be reviewed independently from the less-important issues in that PR.
