### PR TITLE
[JENKINS-55139] Handle redundant occurrences of SGR0 in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Your contribution here.
 * [#137](https://github.com/jenkinsci/ansicolor-plugin/pull/137): Allow escape sequences to span multiple lines and support color maps that set default background/foreground colors - [@dwnusbaum](https://github.com/dwnusbaum).
+* [#147](https://github.com/jenkinsci/ansicolor-plugin/pull/147): Handle redundant occurrences of SGR0 in build logs - [@dwnusbaum](https://github.com/dwnusbaum).
 
 0.6.1 (01/04/2019)
 ============

--- a/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
@@ -28,6 +28,12 @@ class AnsiAttributeElement implements Serializable {
 
     public static interface Emitter {
         public void emitHtml(String html);
+        /**
+         * Called when SGR0 (Set Graphics Rendition 0) reset is encountered in the stream, but no tags have been opened
+         * since its last occurrence. If you are using the output of AnsiOutputStream directly, you probably don't need
+         * to implement this method since the escape sequence will be transparently filtered from the output.
+         */
+        default void emitRedundantReset() { }
     }
 
     public AnsiAttributeElement(AnsiAttrType ansiAttrType, String name, String attributes) {

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -120,6 +120,12 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
     }
 
     private void closeOpenTags(AnsiAttrType until) throws IOException {
+        // If this method is called because we saw SGR0 (reset graphics), but there are no open tags to close, then the
+        // current SGR0 is redundant. If `until` is null, then instead of seeing SGR0 it means the stream is closing,
+        // so we don't do anything special.
+        if (until == AnsiAttrType.DEFAULT && (openTags.isEmpty() || openTags.get(0).ansiAttrType == AnsiAttrType.DEFAULT)) {
+            emitter.emitRedundantReset();
+        }
         while (!openTags.isEmpty()) {
             int index = openTags.size() - 1;
             if (until != null && openTags.get(index).ansiAttrType == until)

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -86,19 +86,25 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                     if (inCount == 1) {
                         inCount = 0;
                     }
-                    LOGGER.log(Level.FINEST, "emitting {0} @{1}/{2}", new Object[] { html, inCount, text.getText().length() });
-                    text.addMarkup(inCount, html);
+                    if (html != null) {
+                        LOGGER.log(Level.FINEST, "emitting {0} @{1}/{2}", new Object[] { html, inCount, s.length() });
+                        text.addMarkup(inCount, html);
+                    }
                     if (inCount != lastPoint) {
                         lastPoint = inCount;
                         int hide = inCount - outCount;
                         // If openTags is not empty, but there are no escape sequences directly on this line, or if we
                         // are emitting closing tags when closing the stream, there is nothing to hide.
                         if (hide != 0) {
-                            LOGGER.log(Level.FINEST, "hiding {0} @{1}", new Object[] { hide, outCount });
+                            LOGGER.log(Level.FINEST, "hiding {0} @{1}{2}", new Object[] { hide, outCount, html == null ? " (ANSI sequence with no corresponding HTML tags)" : "" });
                             text.addMarkup(outCount, outCount + hide, "<!--", "-->");
                             adjustment += hide;
                         }
                     }
+                }
+                @Override
+                public void emitRedundantReset() {
+                    emitHtml(null);
                 }
             }
             EmitterImpl emitter = new EmitterImpl();


### PR DESCRIPTION
Fixes #145 (specifically variant 2 noted in https://github.com/jenkinsci/ansicolor-plugin/issues/145#issuecomment-452858635). See also [JENKINS-55139](https://issues.jenkins-ci.org/browse/JENKINS-55139).

Some tools, such as Terraform and Ansible, emit SGR0 (`ESC [ 0 m`) ANSI sequences even when display settings have not been changed since the last occurrence of SGR0. Since display settings are unchanged, no HTML is emitted, so our way of hiding control sequences using MarkupText does not work correctly. In 0.5.x and earlier, this wasn't a problem because all ANSI sequences were filtered from the underlying stream unconditionally, but now we ignore the output of the stream, so we have to account for these redundant sequences. We could try to fix those tools specifically, but if at least 2 tools are doing this I would not be surprised if it is more common in general, so it seems reasonable to handle it more gracefully here.

My approach to fix the issue was to add a new method to `AnsiAttributeElement.Emitter` used specifically for this purpose. Maybe it would be better just call `emitter.emitHtml(null)` directly in `AnsiHtmlOutputStream` and add documentation to that method that the argument may be `null` under some circumstances (Although I think [updatebot-plugin](https://github.com/jenkinsci/updatebot-plugin/blob/4c8db79c112b670320b23596b01382f17a2de94c/src/main/java/hudson/plugins/ansicolor/AnsiHelper.java) would break if we did so, maybe we could switch to using the empty string instead to avoid that problem).

What text similar to the `testRedundantResets` test case looks like before the change (note that `info` has been hidden!):
<img width="391" alt="screen shot 2019-01-09 at 15 04 12" src="https://user-images.githubusercontent.com/1068968/50998164-a4256280-14f4-11e9-9d55-f36905e5f56b.png">

and after:
<img width="379" alt="screen shot 2019-01-09 at 15 07 03" src="https://user-images.githubusercontent.com/1068968/50998175-a8ea1680-14f4-11e9-8037-fc1832ea70d2.png">
