### PR TITLE
Bump structs from 1.17 to 1.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.17</version>
+        <version>1.20</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -155,7 +155,7 @@ public class AnsiColorBuildWrapperTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                         "node('!master') {\n"
-                        + "  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 1, 'defaultBg': 2]) {\n"
+                        + "  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {\n"
                         + "    sh(\"\"\"#!/bin/bash\n"
                         + "      printf 'The following word is supposed to be \\\\e[31mred\\\\e[0m\\\\n'\"\"\"\n"
                         + "    )\n"


### PR DESCRIPTION
Bump structs from 1.17 to 1.20. See [the changelog](https://wiki.jenkins.io/display/JENKINS/Structs+plugin) and the full diff in [the compare view](https://github.com/jenkinsci/structs-plugin/compare/structs-parent-1.17...structs-parent-1.20).

The main issue with this upgrade was a test that started failing with this exception:

```
java.lang.IllegalArgumentException: WARNING: Unknown parameter(s) found for class type 'hudson.plugins.ansicolor.AnsiColorBuildWrapper': defaultBg,defaultFg
	at org.jenkinsci.plugins.structs.describable.DescribableModel.instantiate(DescribableModel.java:322)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.coerce(DescribableModel.java:474)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.buildArguments(DescribableModel.java:409)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.instantiate(DescribableModel.java:329)
```

Looking into it further, I see that this is a result of jenkinsci/structs-plugin#49, which exposed a bug in this plugin's tests. The bug is that the tests use `defaultFg` and `defaultBg` arguments that are in fact invalid. They were valid at one point, but they were removed from the `@DataBoundConstructor` in 676c11d1ed642c7742373e40dfb1f3160c026dd2. The tests previously passed under the old version of `structs`, but the new version is more strict and doesn't tolerate invalid arguments. Therefore, I've fixed the test by removing the unnecessary arguments.