### PR TITLE
Allow global setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * [#163](https://github.com/jenkinsci/ansicolor-plugin/pull/163): Use OpenJDK on Trusty Linux in Travis-CI - [@dblock](https://github.com/dblock).
 * [#163](https://github.com/jenkinsci/ansicolor-plugin/pull/163): Cache maven installation in Travis-CI - [@dblock](https://github.com/dblock).
+* [#165](https://github.com/jenkinsci/ansicolor-plugin/pull/165): Allow for specifying a global color map - [@kcboschert](https://github.com/kcboschert).
 * Your contribution here.
 
 0.6.2 (01/31/2019)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
@@ -56,6 +56,7 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 @SuppressWarnings("unused")
 public final class AnsiColorBuildWrapper extends SimpleBuildWrapper implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final String colorMapName;
 
@@ -90,6 +91,8 @@ public final class AnsiColorBuildWrapper extends SimpleBuildWrapper implements S
 
         private AnsiColorMap[] colorMaps = new AnsiColorMap[0];
 
+        private String globalColorMapName;
+
         public DescriptorImpl() {
             super(AnsiColorBuildWrapper.class);
             load();
@@ -113,6 +116,8 @@ public final class AnsiColorBuildWrapper extends SimpleBuildWrapper implements S
             try {
                 setColorMaps(req.bindJSONToList(AnsiColorMap.class,
                         req.getSubmittedForm().get("colorMap")).toArray(new AnsiColorMap[1]));
+                setGlobalColorMapName(req.getSubmittedForm().getString("globalColorMapName"));
+                save();
                 return true;
             } catch (ServletException e) {
                 throw new FormException(e, "");
@@ -124,13 +129,20 @@ public final class AnsiColorBuildWrapper extends SimpleBuildWrapper implements S
             return (value.trim().length() == 0) ? FormValidation.error("Name cannot be empty.") : FormValidation.ok();
         }
 
+        public String getGlobalColorMapName() {
+            return globalColorMapName;
+        }
+
+        public void setGlobalColorMapName(String colorMapName) {
+            globalColorMapName = colorMapName;
+        }
+
         public AnsiColorMap[] getColorMaps() {
             return withDefaults(colorMaps);
         }
 
         public void setColorMaps(AnsiColorMap[] maps) {
             colorMaps = maps.clone();
-            save();
         }
 
         public AnsiColorMap getColorMap(final String name) {

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -161,6 +161,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                 if (action != null) {
                     return new ColorConsoleAnnotator(action.colorMapName);
                 }
+                return getGlobalConsoleAnnotator();
             } else if (Jenkins.get().getPlugin("workflow-api") != null && context instanceof FlowNode) {
                 FlowNode node = (FlowNode) context;
                 FlowExecutionOwner owner = node.getExecution().getOwner();
@@ -178,6 +179,15 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                         }
                     }
                 }
+                return getGlobalConsoleAnnotator();
+            }
+            return null;
+        }
+
+        private ConsoleAnnotator<Object> getGlobalConsoleAnnotator() {
+            String globalColorMapName = Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).getGlobalColorMapName();
+            if (globalColorMapName != null && !globalColorMapName.equals("")) {
+                return new ColorConsoleAnnotator(globalColorMapName);
             }
             return null;
         }

--- a/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/global.jelly
+++ b/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/global.jelly
@@ -1,6 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 <f:section title="ANSI Color">
+	<f:entry title="${%Global color map for all builds}" field="globalColorMapName">
+		<f:textbox/>
+	</f:entry>
 	<f:advanced>
 	<f:entry title="Custom color maps">
 		<f:repeatable var="colorMap" items="${descriptor.colorMaps}" add="Add color map">

--- a/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/help-globalColorMapName.html
+++ b/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/help-globalColorMapName.html
@@ -1,0 +1,4 @@
+<div>
+    This is the name of the color map to enable for all projects. This can be overridden at the project level.
+    Leave this blank to not colorize output by default.
+</div>

--- a/src/test/java/hudson/plugins/ansicolor/ColorConsoleAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/ColorConsoleAnnotatorTest.java
@@ -1,0 +1,74 @@
+package hudson.plugins.ansicolor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringWriter;
+import java.util.logging.Level;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import jenkins.model.Jenkins;
+
+public class ColorConsoleAnnotatorTest {
+
+    public ColorConsoleAnnotatorTest() {
+    }
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(ColorConsoleAnnotator.class, Level.FINER);
+
+    @Test
+    public void testGlobalPipelineColorMap() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName("xterm");
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(
+                                "echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'"
+                        , true));
+                WorkflowRun run = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                StringWriter writer = new StringWriter();
+                p.getLastBuild().getLogText().writeHtmlTo(0L, writer);
+                String html = writer.toString();
+                assertTrue("Failed to match color attribute in following HTML log output:\n" + html,
+                        html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
+            }
+        });
+    }
+
+    @Test
+    public void testNoGlobalPipelineColorMap() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName(null);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(
+                                "echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'"
+                        , true));
+                WorkflowRun run = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                StringWriter writer = new StringWriter();
+                p.getLastBuild().getLogText().writeHtmlTo(0L, writer);
+                String html = writer.toString();
+                assertFalse("Color attribute was applied in following HTML log output even though the color map was not globally enabled:\n" + html,
+                        html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
+            }
+        });
+    }
+}


### PR DESCRIPTION
This allows for configuring a global color map name.

![Screen Shot 2019-09-20 at 11 13 55 AM](https://user-images.githubusercontent.com/71199/65342161-c26d5300-db97-11e9-883a-299b7f9e8d75.png)

This resolves #2.