### PR TITLE
Work with moving sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * [#163](https://github.com/jenkinsci/ansicolor-plugin/pull/163): Use OpenJDK on Trusty Linux in Travis-CI - [@dblock](https://github.com/dblock).
 * [#163](https://github.com/jenkinsci/ansicolor-plugin/pull/163): Cache maven installation in Travis-CI - [@dblock](https://github.com/dblock).
 * [#165](https://github.com/jenkinsci/ansicolor-plugin/pull/165): Allow for specifying a global color map - [@kcboschert](https://github.com/kcboschert).
+* [#168](https://github.com/jenkinsci/ansicolor-plugin/pull/168): Fix for working with moving sequences and other invisible escape codes - [@tszmytka](https://github.com/tszmytka)
+* [#169](https://github.com/jenkinsci/ansicolor-plugin/pull/169): Set up config and jenkins pipeline for testing/building the plugin on ci.jenkins.io - [@tszmytka](https://github.com/tszmytka)
 * Your contribution here.
 
 0.6.2 (01/31/2019)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
@@ -1,23 +1,22 @@
 package hudson.plugins.ansicolor;
 
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 
 /**
  * Represents an HTML elements which maps to an ANSI attribute.
- *
- * An ANSI attribute change may open a new element or close an earlier one (e.g. "bold" opens, "bold off" closes).
- * Because HTML elements cannot overlap, any other enclosing element must be closed beforehand and subsequently
- * reopened.
- *
- * How the HTML is actually emitted depends on the specified {@link AnsiAttributeElement.Emitter}.
- * For Jenkins, the Emitter creates {@link hudson.console.ConsoleNote}s as part of the stream, but for
+ * <p>
+ * An ANSI attribute change may open a new element or close an earlier one (e.g. "bold" opens, "bold off" closes). Because HTML elements cannot overlap, any other enclosing element must be closed
+ * beforehand and subsequently reopened.
+ * <p>
+ * How the HTML is actually emitted depends on the specified {@link AnsiAttributeElement.Emitter}. For Jenkins, the Emitter creates {@link hudson.console.ConsoleNote}s as part of the stream, but for
  * other software or testing the HTML may be emitted otherwise.
  */
 
 class AnsiAttributeElement implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public static enum AnsiAttrType {
+    public enum AnsiAttrType {
         DEFAULT, BOLD, ITALIC, UNDERLINE, STRIKEOUT, FRAMED, OVERLINE, FG, BG, FGBG
     }
 
@@ -26,14 +25,20 @@ class AnsiAttributeElement implements Serializable {
     String name;
     String attributes;
 
-    public static interface Emitter {
-        public void emitHtml(String html);
+    public interface Emitter {
+        void emitHtml(@Nonnull String html);
+
         /**
-         * Called when SGR0 (Set Graphics Rendition 0) reset is encountered in the stream, but no tags have been opened
-         * since its last occurrence. If you are using the output of AnsiOutputStream directly, you probably don't need
-         * to implement this method since the escape sequence will be transparently filtered from the output.
+         * Emit invisible ANSI sequence
+         * <p>
+         * Used for emitting output for sequences like:
+         * <li>SGR0 (Set Graphics Rendition 0)
+         * <li>CSI (Control Sequence Introducer)
+         * <p>
+         * In particular called when SGR0 reset is encountered in the stream, but no tags have been opened since its last occurrence. If you are using the output of AnsiOutputStream directly, you
+         * probably don't need to implement this method since the escape sequence will be transparently filtered from the output.
          */
-        default void emitRedundantReset() { }
+        default void emitInvisibleSequence() { }
     }
 
     public AnsiAttributeElement(AnsiAttrType ansiAttrType, String name, String attributes) {
@@ -106,7 +111,6 @@ class AnsiAttributeElement implements Serializable {
 
     public static AnsiAttributeElement overline() {
         return new AnsiAttributeElement(AnsiAttrType.OVERLINE, "span", "style=\"text-decoration: overline;\"");
-        // return new AnsiAttributeElement(AnsiAttrType.OVERLINE, "span", "style=\"border-top: 1px solid;\""); // alternate approach
     }
 
 }

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
@@ -13,6 +13,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.JenkinsJVM;
 
+import javax.annotation.Nonnull;
+
 /**
  * {@link ConsoleLogFilter} that adds a {@link SimpleHtmlNote} to each line.
  * @deprecated Only here for serial form compatibility.
@@ -79,7 +81,7 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
 
         return new AnsiHtmlOutputStream(logger, colorMap, new AnsiAttributeElement.Emitter() {
             @Override
-            public void emitHtml(String html) {
+            public void emitHtml(@Nonnull String html) {
                 try {
                     byte[] pregenerated = notes.get(html);
                     if (pregenerated != null) {

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -124,7 +124,7 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
         // current SGR0 is redundant. If `until` is null, then instead of seeing SGR0 it means the stream is closing,
         // so we don't do anything special.
         if (until == AnsiAttrType.DEFAULT && (openTags.isEmpty() || openTags.get(0).ansiAttrType == AnsiAttrType.DEFAULT)) {
-            emitter.emitRedundantReset();
+            emitter.emitInvisibleSequence();
         }
         while (!openTags.isEmpty()) {
             int index = openTags.size() - 1;
@@ -630,30 +630,101 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
     
     @Override
     protected void processEraseLine(int eraseOption) throws IOException {
-        emitNothing();
+        emitter.emitInvisibleSequence();
     }
 
     @Override
     protected void processCursorDown(int count) throws IOException {
-        emitNothing();
+        emitter.emitInvisibleSequence();
     }
 
     @Override
     protected void processCursorUp(int count) throws IOException {
-        emitNothing();
+        emitter.emitInvisibleSequence();
     }
 
     @Override
     protected void processCursorLeft(int count) throws IOException {
-        emitNothing();
+        emitter.emitInvisibleSequence();
     }
 
     @Override
     protected void processCursorUpLine(int count) throws IOException {
-        emitNothing();
+        emitter.emitInvisibleSequence();
     }
 
-    private void emitNothing() {
-        emitter.emitHtml("");
+    @Override
+    protected void processRestoreCursorPosition() throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processSaveCursorPosition() throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processScrollDown(int optionInt) throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processScrollUp(int optionInt) throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processEraseScreen(int eraseOption) throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processCursorTo(int row, int col) throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processCursorToColumn(int x) throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processCursorDownLine(int count) throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processCursorRight(int count) throws IOException {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processUnknownExtension(ArrayList<Object> options, int command) {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processChangeIconNameAndWindowTitle(String label) {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processChangeIconName(String label) {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processChangeWindowTitle(String label) {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processUnknownOperatingSystemCommand(int command, String param) {
+        emitter.emitInvisibleSequence();
+    }
+
+    @Override
+    protected void processCharsetSelect(int set, char seq) {
+        emitter.emitInvisibleSequence();
     }
 }

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -704,11 +704,6 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
     }
 
     @Override
-    protected void processChangeIconNameAndWindowTitle(String label) {
-        emitter.emitInvisibleSequence();
-    }
-
-    @Override
     protected void processChangeIconName(String label) {
         emitter.emitInvisibleSequence();
     }

--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -627,4 +627,33 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
     protected void processDefaultBackgroundColor() throws IOException {
         setBackgroundColor(null);
     }
+    
+    @Override
+    protected void processEraseLine(int eraseOption) throws IOException {
+        emitNothing();
+    }
+
+    @Override
+    protected void processCursorDown(int count) throws IOException {
+        emitNothing();
+    }
+
+    @Override
+    protected void processCursorUp(int count) throws IOException {
+        emitNothing();
+    }
+
+    @Override
+    protected void processCursorLeft(int count) throws IOException {
+        emitNothing();
+    }
+
+    @Override
+    protected void processCursorUpLine(int count) throws IOException {
+        emitNothing();
+    }
+
+    private void emitNothing() {
+        emitter.emitHtml("");
+    }
 }

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -55,7 +55,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
     private final String colorMapName;
     private final @Nonnull List<AnsiAttributeElement> openTags;
 
-    ColorConsoleAnnotator(String colorMapName, List<AnsiAttributeElement> openTags) {
+    ColorConsoleAnnotator(String colorMapName, @Nonnull List<AnsiAttributeElement> openTags) {
         this.colorMapName = colorMapName;
         this.openTags = openTags;
         LOGGER.log(Level.FINE, "creating annotator with colorMapName={0} openTags={1}", new Object[] { colorMapName, openTags });
@@ -66,7 +66,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
     }
 
     @Override
-    public ConsoleAnnotator<Object> annotate(Object context, MarkupText text) {
+    public ConsoleAnnotator<Object> annotate(@Nonnull Object context, MarkupText text) {
         String s = text.getText();
         List<AnsiAttributeElement> nextOpenTags = openTags;
         AnsiColorMap colorMap = Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).getColorMap(colorMapName);
@@ -77,34 +77,43 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
                 int adjustment;
                 int lastPoint = -1; // multiple HTML tags may be emitted for one control sequence
                 @Override
-                public void emitHtml(String html) {
-                    int inCount = incoming.getCount();
-                    int outCount = outgoing.getCount() + adjustment;
-                    // All ANSI escapes sequences contain at least 2 bytes on modern platforms, so any HTML emitted
-                    // directly after the first character is received is due to the initialization process of the stream and
-                    // belongs at position 0 (i.e. default background/foreground colors).
-                    if (inCount == 1) {
-                        inCount = 0;
-                    }
-                    if (html != null) {
-                        LOGGER.log(Level.FINEST, "emitting {0} @{1}/{2}", new Object[] { html, inCount, s.length() });
-                        text.addMarkup(inCount, html);
-                    }
+                public void emitHtml(@Nonnull String html) {
+                    final int inCount = getIncomingCount();
+                    LOGGER.log(Level.FINEST, "emitting {0} @{1}/{2}", new Object[] { html, inCount, s.length() });
+                    text.addMarkup(inCount, html);
+                    hideIfNeeded(inCount, "");
+                }
+
+                /**
+                 * All ANSI escapes sequences contain at least 2 bytes on modern platforms, so any HTML emitted
+                 * directly after the first character is received is due to the initialization process of the stream and
+                 * belongs at position 0 (i.e. default background/foreground colors).
+                 *
+                 * @return Incoming chars count
+                 */
+                private int getIncomingCount() {
+                    final int inCount = incoming.getCount();
+                    return inCount == 1 ? 0 : inCount;
+                }
+
+                private void hideIfNeeded(int inCount, String msg) {
                     if (inCount != lastPoint) {
                         lastPoint = inCount;
-                        int hide = inCount - outCount;
+                        final int outCount = outgoing.getCount() + adjustment;
+                        final int hide = inCount - outCount;
                         // If openTags is not empty, but there are no escape sequences directly on this line, or if we
                         // are emitting closing tags when closing the stream, there is nothing to hide.
                         if (hide != 0) {
-                            LOGGER.log(Level.FINEST, "hiding {0} @{1}{2}", new Object[] { hide, outCount, html == null ? " (ANSI sequence with no corresponding HTML tags)" : "" });
+                            LOGGER.log(Level.FINEST, "hiding {0} @{1}{2}", new Object[] { hide, outCount, msg});
                             text.addMarkup(outCount, outCount + hide, "<!--", "-->");
                             adjustment += hide;
                         }
                     }
                 }
+
                 @Override
-                public void emitRedundantReset() {
-                    emitHtml(null);
+                public void emitInvisibleSequence() {
+                    hideIfNeeded(getIncomingCount(), " (ANSI sequence with no corresponding HTML tags)");
                 }
             }
             EmitterImpl emitter = new EmitterImpl();

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -33,6 +33,7 @@ public class AnsiColorBuildWrapperTest {
     private static final String ESC = "\033";
     private static final String CLR = ESC + "[2K";
 
+    @SuppressWarnings("unused")
     private enum CSI {
         CUU("A", 1),
         CUD("B", 1),

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -261,9 +261,6 @@ public class AnsiColorBuildWrapperTest {
 
     @Test
     public void canWorkWithMovingSequences() {
-        // https://en.wikipedia.org/wiki/ANSI_escape_code
-        // https://github.com/jenkinsci/ansicolor-plugin/issues/151
-        // seems to have beem working correctly in ansicolor-0.5.3
         final String op1 = "Creating container_1";
         final String op2 = "Creating container_2";
         final String up2lines = move(2, "A");

--- a/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiHtmlOutputStreamTest.java
@@ -31,6 +31,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
+
 public class AnsiHtmlOutputStreamTest {
 
     @Test
@@ -613,7 +615,7 @@ public class AnsiHtmlOutputStreamTest {
     private String annotate(String text, AnsiColorMap colorMap) throws IOException {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         AnsiHtmlOutputStream ansi = new AnsiHtmlOutputStream(bos, colorMap, new AnsiAttributeElement.Emitter() {
-            public void emitHtml(String html) {
+            public void emitHtml(@Nonnull String html) {
                 try {
                     bos.write(html.getBytes("UTF-8"));
                 } catch (IOException e) {


### PR DESCRIPTION
Currently the plugin incorrectly handles control sequences like:
- `CUU` Cursor Up
- `CUD` Cursor Down
- `CUF` Cursor Forward
- `CUB` Cursor Back
- `EL` Erase in Line

Using many popular tools in a job, like `docker`, produces output similar to:
```
+ docker-compose down
Stopping container_1               ... 
Stopping container_2               ... 
Stopping container_3               ... 
[4A[2K
Stopping container_1               done
[4B[2A[2K
```

This PR contains a fix - the mentioned sequences will not produce any output - as well as a test case against regression.
Merging this may very well fix https://github.com/jenkinsci/ansicolor-plugin/issues/151 as the actual problem looks very similar.