### PR TITLE
Provide a basic Jenkinsfile to utilize testing on jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.48</version>
+    <version>3.56</version>
     <relativePath />
   </parent>
 
@@ -42,7 +42,7 @@
   <properties>
     <revision>0.6.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.145</jenkins.version> <!-- to pick up https://github.com/jenkinsci/jenkins/pull/3662 -->
+    <jenkins.version>2.164.3</jenkins.version> <!-- to pick up https://github.com/jenkinsci/jenkins/pull/3662 -->
     <java.level>8</java.level>
   </properties>
 
@@ -50,51 +50,42 @@
     <dependency>
      <groupId>org.jenkins-ci.plugins.workflow</groupId>
      <artifactId>workflow-step-api</artifactId>
-     <version>2.15</version>
      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.30</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.59</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.26</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>structs</artifactId>
-        <version>1.20</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>scm-api</artifactId>
-        <version>2.2.6</version>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.164.x</artifactId>
+        <version>5</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -111,4 +111,15 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -185,7 +185,6 @@ public class AnsiColorBuildWrapperTest {
     @Test
     public void testNonAscii() throws Exception {
         story.then(r -> {
-            Assume.assumeTrue(!Functions.isWindows());
             FreeStyleProject p = r.createFreeStyleProject();
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
             p.getBuildersList().add(new TestBuilder() {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -185,6 +185,7 @@ public class AnsiColorBuildWrapperTest {
     @Test
     public void testNonAscii() throws Exception {
         story.then(r -> {
+            Assume.assumeTrue(!Functions.isWindows());
             FreeStyleProject p = r.createFreeStyleProject();
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
             p.getBuildersList().add(new TestBuilder() {
@@ -192,7 +193,7 @@ public class AnsiColorBuildWrapperTest {
                 public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                     listener.getLogger().println("\033[94;1m[ INFO ] Récupération du numéro de version de l'application\033[0m");
                     listener.getLogger().println("\033[94;1m[ INFO ] ビルドのコンソール出力を取得します。\033[0m");
-                     // There are 3 smiley face emojis in this String
+                    // There are 3 smiley face emojis in this String
                     listener.getLogger().println("\033[94;1m[ INFO ] 😀😀\033[0m😀");
                     return true;
                 }
@@ -201,12 +202,14 @@ public class AnsiColorBuildWrapperTest {
             StringWriter writer = new StringWriter();
             b.getLogText().writeHtmlTo(0L, writer);
             String html = writer.toString();
-            System.out.print(html);
-            assertThat(html.replaceAll("<!--.+?-->", ""),
+            assertThat(
+                html.replaceAll("<!--.+?-->", ""),
                 allOf(
                     containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] Récupération du numéro de version de l'application</b></span>"),
                     containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] ビルドのコンソール出力を取得します。</b></span>"),
-                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] 😀😀</b></span>😀")));
+                    containsString("<span style=\"color: #4682B4;\"><b>[ INFO ] 😀😀</b></span>😀")
+                )
+            );
         });
     }
 


### PR DESCRIPTION
This PR allows for running tests on [ci.jenkins.io](http://ci.jenkins.io).
The used `buildPlugin.recommendedConfigurations()` contain (among others) 
`[ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],` so a separate CI service (AppVeyor or any other) would not be needed.