### PR TITLE
172 sgr effect normal intensity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.6.4 (Next)
 ============
 
+* [#173](https://github.com/jenkinsci/ansicolor-plugin/pull/173): Fix for SGR Normal intensity not handled correctly - [@tszmytka](https://github.com/tszmytka)
 * Your contribution here.
 
 0.6.3 (02/24/2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 0.6.4 (Next)
 ============
 
-* [#173](https://github.com/jenkinsci/ansicolor-plugin/pull/173): Fix for SGR Normal intensity not handled correctly - [@tszmytka](https://github.com/tszmytka)
+* [#173](https://github.com/jenkinsci/ansicolor-plugin/pull/173): Fix for SGR Normal intensity not handled correctly - [@tszmytka](https://github.com/tszmytka).
 * Your contribution here.
 
 0.6.3 (02/24/2020)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiAttributeElement.java
@@ -12,12 +12,11 @@ import java.io.Serializable;
  * How the HTML is actually emitted depends on the specified {@link AnsiAttributeElement.Emitter}. For Jenkins, the Emitter creates {@link hudson.console.ConsoleNote}s as part of the stream, but for
  * other software or testing the HTML may be emitted otherwise.
  */
-
 class AnsiAttributeElement implements Serializable {
     private static final long serialVersionUID = 1L;
 
     public enum AnsiAttrType {
-        DEFAULT, BOLD, ITALIC, UNDERLINE, STRIKEOUT, FRAMED, OVERLINE, FG, BG, FGBG
+        DEFAULT, BOLD, FAINT, ITALIC, UNDERLINE, STRIKEOUT, FRAMED, OVERLINE, FG, BG, FGBG
     }
 
     AnsiAttrType ansiAttrType;
@@ -87,6 +86,10 @@ class AnsiAttributeElement implements Serializable {
 
     public static AnsiAttributeElement bold() {
         return new AnsiAttributeElement(AnsiAttributeElement.AnsiAttrType.BOLD, "b", "");
+    }
+
+    public static AnsiAttributeElement faint() {
+        return new AnsiAttributeElement(AnsiAttributeElement.AnsiAttrType.FAINT, "span", "style=\"font-weight: lighter;\"");
     }
 
     public static AnsiAttributeElement italic() {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -48,7 +48,6 @@ public class AnsiColorBuildWrapperTest {
         SU("S", 1),
         SD("T", 1),
         HVP("f", 2),
-        SGR("m", 1),
         AUXON("5i", 0),
         AUXOFF("4i", 0),
         DSR("6n", 0),
@@ -356,7 +355,6 @@ public class AnsiColorBuildWrapperTest {
             }
             throw new IllegalArgumentException("Not supported amount of params");
         }).collect(Collectors.toList());
-
         final String txt1 = "Test various sequences end";
         final Consumer<PrintStream> inputProvider = stream -> {
             stream.println(txt0);
@@ -395,9 +393,38 @@ public class AnsiColorBuildWrapperTest {
                 "<span style=\"color: #00FF00;\">" + msg1 + "</span>",
                 "<span style=\"color: #00FF00;\"><b>" + msg2 + "</b></span>",
                 "<span style=\"color: #00FF00;\">" + msg3 + "</span>",
-                "<span style=\"color: #00FF00;\">" + msg4 + "</span>"
+                "<span style=\"color: #00FF00;\">" + msg4 + "</span>",
+                msg5
             ),
             Arrays.asList(sgrReset, sgrLightGreen, sgrLightGreenRegular, sgrBold, sgrNormal),
+            inputProvider
+        );
+    }
+
+    @Test
+    public void canRenderSgrFaintIntensity() {
+        final String sgrReset = sgr(0);
+        final String msg0 = "lightblue and also faint";
+        final String sgrLightBlueFaint = sgr(94, 2);
+        final String msg1 = "lightblue and";
+        final String msg2 = "also faint";
+        final String sgrLightBlue = sgr(94);
+        final String sgrFaint = sgr(2);
+        final String msg3 = "normal ordinary text";
+        final String sgrNormal = sgr(22);
+
+        final Consumer<PrintStream> inputProvider = stream -> {
+            stream.println(sgrLightBlueFaint + msg0 + sgrReset);
+            stream.println(sgrLightBlue + msg1 + sgrFaint + msg2 + sgrReset);
+            stream.println(sgrLightBlue + sgrFaint + sgrNormal + msg3 + sgrReset);
+        };
+        assertCorrectOutput(
+            Arrays.asList(
+                "<span style=\"color: #4682B4;\"><span style=\"font-weight: lighter;\">" + msg0 + "</span></span>",
+                "<span style=\"color: #4682B4;\">" + msg1 + "<span style=\"font-weight: lighter;\">" + msg2 + "</span></span>",
+                msg3
+            ),
+            Arrays.asList(sgrReset, sgrLightBlueFaint, sgrLightBlue, sgrFaint, sgrNormal),
             inputProvider
         );
     }
@@ -419,7 +446,7 @@ public class AnsiColorBuildWrapperTest {
     }
 
     private static String sgr(int... sgrParam) {
-        return ESC + "[" + Arrays.stream(sgrParam).boxed().map(String::valueOf).collect(Collectors.joining(";")) + CSI.SGR.code;
+        return ESC + "[" + Arrays.stream(sgrParam).boxed().map(String::valueOf).collect(Collectors.joining(";")) + "m";
     }
 
     private void assertCorrectOutput(Collection<String> expectedOutput, Collection<String> notExpectedOutput, Consumer<PrintStream> inputProvider) {


### PR DESCRIPTION
This is a fix for #172 
Problem was that "SGR Normal intensity" `ESC[22m` was handled correctly **only** if output already contained an html tag `b` opened for "SGR Bold" `ESC[1m` sequence. In other cases it caused no output tags to be generated and the sequence itself was also not commented out.

This PR adds commenting out of any attribute-changing sequence which does not produce output.
Additionally I've added implementation for "SGR Faint" `ESC[2m` similarly to "SGR Bold" `ESC[1m` along with tests.