### PR TITLE
Ensure extended color SGRs are recognized correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * [#173](https://github.com/jenkinsci/ansicolor-plugin/pull/173): Fix for SGR Normal intensity not handled correctly - [@tszmytka](https://github.com/tszmytka).
+* [#176](https://github.com/jenkinsci/ansicolor-plugin/pull/176): Ensure extended color SGRs are recognized correctly - [@tszmytka](https://github.com/tszmytka).
 * Your contribution here.
 
 0.6.3 (02/24/2020)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiOutputStream.java
@@ -305,7 +305,7 @@ public class AnsiOutputStream extends FilterOutputStream {
                         Object next = optionsIterator.next();
                         if (next != null) {
                             count++;
-                            int value = ((Integer) next).intValue();
+                            int value = (Integer) next;
                             if (30 <= value && value <= 37) {
                                 processSetForegroundColor(value - 30);
                             } else if (40 <= value && value <= 47) {
@@ -314,7 +314,7 @@ public class AnsiOutputStream extends FilterOutputStream {
                                 processSetForegroundColor(value - 90, true);
                             } else if (100 <= value && value <= 107) {
                                 processSetBackgroundColor(value - 100, true);
-                            } else if (value == 38 || value == 48) {
+                            } else if ((value == 38 || value == 48) && count == 1) {
                                 // extended color like `esc[38;5;<index>m` or `esc[38;2;<r>;<g>;<b>m`
                                 int arg2or5 = getNextOptionInt(optionsIterator);
                                 if (arg2or5 == 2) {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -425,6 +426,22 @@ public class AnsiColorBuildWrapperTest {
                 msg3
             ),
             Arrays.asList(sgrReset, sgrLightBlueFaint, sgrLightBlue, sgrFaint, sgrNormal),
+            inputProvider
+        );
+    }
+
+    @Issue("158")
+    @Test
+    public void canHandleSgrsWithMultipleOptions() {
+        final String input = "\u001B[33mbanana_1  |\u001B[0m 19:59:14.353\u001B[0;38m [debug] Lager installed handler {lager_file_backend,\"banana.log\"} into lager_event\u001B[0m\n";
+
+        final Consumer<PrintStream> inputProvider = stream -> {
+            stream.println(input);
+        };
+
+        assertCorrectOutput(
+            Collections.singletonList("<span style=\"color: #CDCD00;\">banana_1  |</span> 19:59:14.353 [debug] Lager installed handler {lager_file_backend,\"banana.log\"} into lager_event"),
+            Collections.singletonList(ESC),
             inputProvider
         );
     }


### PR DESCRIPTION
This is a fix for #158 
`SGR`s with possibly switched options, like
`ESC[5;38m`
have been falling into the same category as
`ESC[38;5m`
but causing exceptions mid-run.

The actual sequence which triggered this (provided by the user)
`ESC[0;38m`
looks strange and I haven't been able to find its full meaning (if there is one) so the fix will allow it to be treated the same way as simply
`ESC[0m`
with no exceptions thrown.
