### PR TITLE
Add instruction for installing via jenkins cli. Improve documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * [#173](https://github.com/jenkinsci/ansicolor-plugin/pull/173): Fix for SGR Normal intensity not handled correctly - [@tszmytka](https://github.com/tszmytka).
 * [#176](https://github.com/jenkinsci/ansicolor-plugin/pull/176): Ensure extended color SGRs are recognized correctly - [@tszmytka](https://github.com/tszmytka).
+* [#156](https://github.com/jenkinsci/ansicolor-plugin/pull/156): Improve documentation - [@tszmytka](https://github.com/tszmytka).
 * Your contribution here.
 
 0.6.3 (02/24/2020)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Jenkins ANSI Color Plugin
 
-[![Build Status](https://travis-ci.org/jenkinsci/ansicolor-plugin.svg)](https://travis-ci.org/jenkinsci/ansicolor-plugin)
+[![Travis Build Status](https://travis-ci.org/jenkinsci/ansicolor-plugin.svg)](https://travis-ci.org/jenkinsci/ansicolor-plugin)
+[![Jenkins Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fansicolor-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/ansicolor-plugin/job/master/)
+[![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/ansicolor)](https://plugins.jenkins.io/ansicolor/)
+[![Jenkins Plugin installs](https://img.shields.io/jenkins/plugin/i/ansicolor)](https://plugins.jenkins.io/ansicolor/)
 
 This plugin adds support for standard ANSI escape sequences, including color, to Console Output.
 
@@ -9,8 +12,15 @@ and has [a page](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin) o
 
 # Install
 
+#### Using Plugin Manager
+
 ![install](images/ansicolor-install.png "Install AnsiColor")
 
+#### Using Jenkins CLI client
+
+```
+java -jar jenkins-cli.jar install-plugin ansicolor
+```
 # Enable
 
 ![enable](images/ansicolor-enable.png "Enable AnsiColor")

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.56</version>
+    <version>4.1</version>
     <relativePath />
   </parent>
 
@@ -42,7 +42,7 @@
   <properties>
     <revision>0.6.4</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.164.3</jenkins.version> <!-- to pick up https://github.com/jenkinsci/jenkins/pull/3662 -->
+    <jenkins.version>2.176.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 


### PR DESCRIPTION
This PR improves the README by addressing a reasonable (in my opinion) request from #156 and adding status badges concerning:
- `ci.jenkins.io` build
- current plugin version
- amount of installs so far