### PR TITLE
Use GitHub README as plugins.jenkins.io docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <name>AnsiColor</name>
   <description>Adds ANSI coloring to the Console Output</description>
-  <url>https://wiki.jenkins.io/display/JENKINS/AnsiColor+Plugin</url>
+  <url>https://github.com/jenkinsci/ansicolor-plugin</url>
   <licenses>
     <license>
       <name>The MIT License</name>


### PR DESCRIPTION
The GitHub README is more detailed than the Jenkins wiki page and provides a better experience for the reader.

See the [blog post](https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/) and the [documentation page](https://www.jenkins.io/doc/developer/publishing/documentation/#documenting-plugins) for more details.