### PR TITLE
#186 Allow rendering more complex sgrs

### DIFF
--- a/src/main/java/hudson/plugins/ansicolor/AnsiOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiOutputStream.java
@@ -314,7 +314,10 @@ public class AnsiOutputStream extends FilterOutputStream {
                                 processSetForegroundColor(value - 90, true);
                             } else if (100 <= value && value <= 107) {
                                 processSetBackgroundColor(value - 100, true);
-                            } else if ((value == 38 || value == 48) && count == 1) {
+                            } else if ((value == 38 || value == 48)) {
+                                if (!optionsIterator.hasNext()) {
+                                    continue;
+                                }
                                 // extended color like `esc[38;5;<index>m` or `esc[38;2;<r>;<g>;<b>m`
                                 int arg2or5 = getNextOptionInt(optionsIterator);
                                 if (arg2or5 == 2) {

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -437,11 +437,24 @@ public class AnsiColorBuildWrapperTest {
     @Test
     public void canHandleSgrsWithMultipleOptions() {
         final String input = "\u001B[33mbanana_1  |\u001B[0m 19:59:14.353\u001B[0;38m [debug] Lager installed handler {lager_file_backend,\"banana.log\"} into lager_event\u001B[0m\n";
-
         final Consumer<PrintStream> inputProvider = stream -> stream.println(input);
-
         assertCorrectOutput(
             Collections.singletonList("<span style=\"color: #CDCD00;\">banana_1  |</span> 19:59:14.353 [debug] Lager installed handler {lager_file_backend,\"banana.log\"} into lager_event"),
+            Collections.singletonList(ESC),
+            inputProvider
+        );
+    }
+
+    @Issue("186")
+    @Test
+    public void canHandleSgrsWithRgbColors() {
+        final String input = "\u001B[1;38;5;4m[fe1.k8sf.atom.us-west-2 ]\u001B[0m\n\u001B[1;38;5;13m[fe1b.k8sf.atom.us-east-2]\u001B[0m";
+        final Consumer<PrintStream> inputProvider = stream -> stream.println(input);
+        assertCorrectOutput(
+            Arrays.asList(
+                "<b><span style=\"color: #1E90FF;\">[fe1.k8sf.atom.us-west-2 ]</span></b>",
+                "<b><span style=\"color: #FF00FF;\">[fe1b.k8sf.atom.us-east-2]</span></b>"
+            ),
             Collections.singletonList(ESC),
             inputProvider
         );


### PR DESCRIPTION
This is a fix for #186 

The initial changes in #176 assumed that 256 color `SGR`s would always *begin* with `38;5`, like :
```
esc[38;5;<index>m
```

Turns out it is possible for them to have attribute(s) before them as well, like:
```
esc[1;38;5;<index>m
```
