### PR TITLE
Running on agent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ max_line_length = 200
 
 [*.xml]
 indent_size = 2
+
+[{*.yml, *.yaml}]
+indent_size = 2

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.2</version>
+    <version>4.3</version>
     <relativePath />
   </parent>
 
@@ -42,7 +42,7 @@
   <properties>
     <revision>0.7.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.176.3</jenkins.version>
+    <jenkins.version>2.204.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
+++ b/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
@@ -29,7 +29,9 @@ import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import hudson.plugins.ansicolor.AnsiColorMap;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static hudson.plugins.ansicolor.action.ActionNote.TAG_ACTION_BEGIN;
 
@@ -81,6 +83,13 @@ public class ColorizedAction extends InvisibleAction {
             final String id = line.substring(from, to);
             return run.getActions(ColorizedAction.class).stream().filter(a -> id.equals(a.getId().toString())).findAny().orElse(CONTINUE);
         }
-        return line.contains(TAG_PIPELINE_INTERNAL) ? IGNORE : CONTINUE;
+        if (line.contains(TAG_PIPELINE_INTERNAL)) {
+            return IGNORE;
+        }
+        final List<ColorizedAction> startActions = run.getActions(ColorizedAction.class).stream().filter(c -> Command.START.equals(c.getCommand())).collect(Collectors.toList());
+        if (startActions.size() == 1) {
+            return startActions.get(0);
+        }
+        return CONTINUE;
     }
 }


### PR DESCRIPTION
This is a workaround for #193 
It recreates the old behavior of triggering the plugin on registration in a pipeline regardless of the actual line of script it's been defined in. In this mode it doesn't check log annotations. This should fix the behavior for everyone reporting `0.6.3` was working fine.

I am assuming that the problem is caused by that fact that log annotations generated in an agent are not getting picked up by the master. It is not possible to reproduce this no matter which Jenkins version (tried `2.176.3`, `2.204.1`) or agent version (tried images `jenkins/inbound-agent:4.3-4-alpine`, `jenkins/jnlp-slave:4.3-4-alpine` and a manually constructed agent on `openjdk:14` ) I use. There probably is something else (security settings?) enabled on a prod-running Jenkins that is not there in dev mode.

If this gets merged we could release a new version.