### PR TITLE
193 interaction timestamper

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Daniel Doubrovkine (dB.) @dblockdotorg <dblock@dblock.org> dblock <dblock@dblock.org>
+Daniel Doubrovkine (dB.) @dblockdotorg <dblock@dblock.org> Daniel Doubrovkine (dB.) <dblock@dblock.org>
+Daniel Doubrovkine (dB.) @dblockdotorg <dblock@dblock.org> Daniel Doubrovkine <dblock@dblock.org>
+Tomek Szmytka <tszmytka@gmail.com> Tomek <tszmytka@gmail.com>
+Tomek Szmytka <tszmytka@gmail.com> Tomek Szmytka <60844785+tszmytka@users.noreply.github.com>
+Devin Nusbaum <d.w.nusbaum@gmail.com> Devin Nusbaum <dwnusbaum@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 0.7.1 (Next)
 ============
 
+* [#188](https://github.com/jenkinsci/ansicolor-plugin/pull/188): Allow rendering more complex sgrs - [@tszmytka](https://github.com/tszmytka).
 * [#190](https://github.com/jenkinsci/ansicolor-plugin/pull/190): Don't leak formatting to metadata console lines - [@tszmytka](https://github.com/tszmytka).
+* [#195](https://github.com/jenkinsci/ansicolor-plugin/pull/195): Running on agent - [@tszmytka](https://github.com/tszmytka).
+* [#196](https://github.com/jenkinsci/ansicolor-plugin/pull/196): Interaction with timestamper - [@tszmytka](https://github.com/tszmytka).
+
 * Your contribution here.
 
 0.7.0 (05/23/2020)

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorStep.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorStep.java
@@ -8,6 +8,7 @@ import hudson.plugins.ansicolor.action.ActionNote;
 import hudson.plugins.ansicolor.action.ColorizedAction;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 import org.jenkinsci.plugins.workflow.steps.*;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -152,9 +153,16 @@ public class AnsiColorStep extends Step {
                 if (taskListener != null && run != null) {
                     run.addAction(action);
                     taskListener.annotate(new ActionNote(action));
+                    ensureRendering(taskListener, context.get(TaskListenerDecorator.class));
                 }
             } catch (IOException | InterruptedException e) {
                 LOGGER.log(Level.WARNING, "Could not annotate. Ansicolor plugin will not work correctly.", e);
+            }
+        }
+
+        private void ensureRendering(TaskListener taskListener, TaskListenerDecorator taskListenerDecorator) {
+            if (taskListenerDecorator != null && taskListenerDecorator.getClass().getName().contains("hudson.plugins.timestamper.pipeline.GlobalDecorator")) {
+                taskListener.getLogger().println();
             }
         }
     }

--- a/src/main/java/hudson/plugins/ansicolor/action/ActionNote.java
+++ b/src/main/java/hudson/plugins/ansicolor/action/ActionNote.java
@@ -9,7 +9,7 @@ import hudson.model.Run;
  * Marker note accompanying a ColorizedAction showing where an action needs to take place
  */
 public class ActionNote extends ConsoleNote<Run<?, ?>> {
-    static final String TAG_ACTION_BEGIN = "<div data-ansicolor-action=";
+    static final String TAG_ACTION_BEGIN = "<div style=\"display:none\" data-ansicolor-action=";
     private static final String TAG_ACTION_ID_TEMPLATE = "\"%s\"";
     static final String TAG_ACTION_END = "></div>";
 

--- a/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
+++ b/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
@@ -29,9 +29,7 @@ import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import hudson.plugins.ansicolor.AnsiColorMap;
 
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static hudson.plugins.ansicolor.action.ActionNote.TAG_ACTION_BEGIN;
 
@@ -83,13 +81,6 @@ public class ColorizedAction extends InvisibleAction {
             final String id = line.substring(from, to);
             return run.getActions(ColorizedAction.class).stream().filter(a -> id.equals(a.getId().toString())).findAny().orElse(CONTINUE);
         }
-        if (line.contains(TAG_PIPELINE_INTERNAL)) {
-            return IGNORE;
-        }
-        final List<ColorizedAction> startActions = run.getActions(ColorizedAction.class).stream().filter(c -> Command.START.equals(c.getCommand())).collect(Collectors.toList());
-        if (startActions.size() == 1) {
-            return startActions.get(0);
-        }
-        return CONTINUE;
+        return line.contains(TAG_PIPELINE_INTERNAL) ? IGNORE : CONTINUE;
     }
 }

--- a/src/test/java/hudson/plugins/ansicolor/action/ColorizedActionTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/action/ColorizedActionTest.java
@@ -66,9 +66,9 @@ public class ColorizedActionTest {
     }
 
     @Test
-    public void willTriggerStartIfThereIsExactlyOneStartActionEvenWithoutCorrespondingAnnotation() {
+    public void willNotTriggerStartIfThereIsExactlyOneStartActionAndNoCorrespondingAnnotation() {
         final MarkupText markupText = new MarkupText("Log line");
-        assertEquals(ACTION_0, ColorizedAction.parseAction(markupText, buildRunSingleStart));
+        assertEquals(CONTINUE, ColorizedAction.parseAction(markupText, buildRunSingleStart));
     }
 
     @Test


### PR DESCRIPTION
This adjustment addresses the problem of `timestamper` plugin decorating the global `logger` with functionality that writes anything to the log **only** if the line ends with a `LF` character, otherwise it gets lost.
The `ansicolor` annotates log lines where its own logic should start/stop with `ConsoleNote`s which get serialized without any special line ending. If those lines are not available in the log upon rendering the whole coloring is not enabled and any special chars end up in the output it their raw form.