### PR TITLE
Render logs correctly for long running jobs which generate lots of logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.7.3 (Next)
 ============
 
+* [#202](https://github.com/jenkinsci/ansicolor-plugin/pull/202): Render logs correctly for long running jobs which generate lots of output - [@tszmytka](https://github.com/tszmytka).
 * Your contribution here.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
       <version>3.16.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.0.3</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
       <artifactId>awaitility</artifactId>
       <version>4.0.3</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorBuildWrapper.java
@@ -64,6 +64,7 @@ public final class AnsiColorBuildWrapper extends SimpleBuildWrapper implements S
 
     /**
      * Create a new {@link AnsiColorBuildWrapper}.
+     * @param colorMapName Name of the color map to use
      */
     @DataBoundConstructor
     public AnsiColorBuildWrapper(String colorMapName) {

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorConsoleLogFilter.java
@@ -24,7 +24,7 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOG = Logger.getLogger(AnsiColorConsoleLogFilter.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(AnsiColorConsoleLogFilter.class.getName());
 
     private AnsiColorMap colorMap;
     private final Map<String, byte[]> notes;
@@ -46,14 +46,14 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
         pregenerateNote(AnsiAttributeElement.framed());
         pregenerateNote(AnsiAttributeElement.overline());
         // TODO other cases, and other methods
-        LOG.log(Level.FINE, "Notes pregenerated for {0}", notes.keySet());
+        LOGGER.log(Level.FINE, "Notes pregenerated for {0}", notes.keySet());
     }
-    
+
     private void pregenerateNote(AnsiAttributeElement element) {
         element.emitOpen(html -> pregenerateNote(html));
         element.emitClose(html -> pregenerateNote(html));
     }
-    
+
     private void pregenerateNote(String html) {
         if (!notes.containsKey(html)) {
             JenkinsJVM.checkJenkinsJVM();
@@ -91,7 +91,7 @@ public final class AnsiColorConsoleLogFilter extends ConsoleLogFilter implements
                         new SimpleHtmlNote(html).encodeTo(logger);
                     }
                 } catch (IOException e) {
-                    LOG.log(Level.WARNING, "Failed to add HTML markup '" + html + "'", e);
+                    LOGGER.log(Level.WARNING, "Failed to add HTML markup '" + html + "'", e);
                 }
             }
         });

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorStep.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorStep.java
@@ -72,6 +72,7 @@ public class AnsiColorStep extends Step {
         @Override
         public boolean start() throws Exception {
             StepContext context = getContext();
+
             EnvironmentExpander currentEnvironment = context.get(EnvironmentExpander.class);
             EnvironmentExpander terminalEnvironment = EnvironmentExpander.constant(Collections.singletonMap("TERM", colorMapName));
             context.newBodyInvoker()
@@ -157,6 +158,14 @@ public class AnsiColorStep extends Step {
                     run.addAction(action);
                     taskListener.annotate(new ActionNote(action));
                     ensureRendering(taskListener);
+                    final ColorizedAction currentAction = new ColorizedAction(action.getColorMapName(), ColorizedAction.Command.CURRENT);
+                    if (action.getCommand().equals(ColorizedAction.Command.START)) {
+                        run.addOrReplaceAction(currentAction);
+                    } else {
+                        run.removeAction(currentAction);
+                    }
+                    run.getId();
+
                 }
             } catch (IOException | InterruptedException e) {
                 LOGGER.log(Level.WARNING, "Could not annotate. Ansicolor plugin will not work correctly.", e);

--- a/src/main/java/hudson/plugins/ansicolor/AnsiColorStep.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiColorStep.java
@@ -160,12 +160,10 @@ public class AnsiColorStep extends Step {
                     ensureRendering(taskListener);
                     final ColorizedAction currentAction = new ColorizedAction(action.getColorMapName(), ColorizedAction.Command.CURRENT);
                     if (action.getCommand().equals(ColorizedAction.Command.START)) {
-                        run.addOrReplaceAction(currentAction);
+                        run.addAction(currentAction);
                     } else {
                         run.removeAction(currentAction);
                     }
-                    run.getId();
-
                 }
             } catch (IOException | InterruptedException e) {
                 LOGGER.log(Level.WARNING, "Could not annotate. Ansicolor plugin will not work correctly.", e);

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -88,6 +88,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
             : ColorizedAction.parseAction(text, run);
         switch (colorizedAction.getCommand()) {
             case START:
+            case CURRENT:
                 colorMapName = colorizedAction.getColorMapName();
                 break;
             case STOP:

--- a/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
+++ b/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
@@ -49,16 +49,13 @@ public class ColorizedAction extends InvisibleAction {
     private final Command command;
 
     public enum Command {
-        /**
-         *
-         */
         START,
         STOP,
         CONTINUE,
         IGNORE,
 
         /**
-         * Currently running execution
+         * The running job's current action containing current color map name
          */
         CURRENT
     }

--- a/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
+++ b/src/main/java/hudson/plugins/ansicolor/action/ColorizedAction.java
@@ -31,6 +31,7 @@ import hudson.plugins.ansicolor.AnsiColorMap;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import static hudson.plugins.ansicolor.action.ActionNote.TAG_ACTION_BEGIN;
 
@@ -38,6 +39,7 @@ import static hudson.plugins.ansicolor.action.ActionNote.TAG_ACTION_BEGIN;
  * Action for issuing commands to ColorConsoleAnnotator
  */
 public class ColorizedAction extends InvisibleAction {
+    private static final Logger LOGGER = Logger.getLogger(ColorizedAction.class.getName());
     private static final String TAG_PIPELINE_INTERNAL = "<span class=\"pipeline-new-node\"";
     static final ColorizedAction CONTINUE = new ColorizedAction("", Command.CONTINUE);
     static final ColorizedAction IGNORE = new ColorizedAction("", Command.IGNORE);
@@ -96,7 +98,9 @@ public class ColorizedAction extends InvisibleAction {
         if (line.contains(TAG_PIPELINE_INTERNAL)) {
             return IGNORE;
         }
-        if (run.isBuilding()) {
+        final boolean isBuilding = run.isBuilding();
+        LOGGER.fine("Run is building: " + isBuilding);
+        if (isBuilding) {
             Optional<ColorizedAction> currentAction = run.getActions(ColorizedAction.class).stream()
                 .filter(a -> Command.CURRENT.equals(a.getCommand()))
                 .findFirst();

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
@@ -147,14 +147,16 @@ public class AnsiColorStepTest {
             public void evaluate() throws Throwable {
                 final String a1k = JenkinsTestSupport.repeat("a", 1024);
                 final String script = "ansiColor('xterm') {\n" +
-                    JenkinsTestSupport.repeat("echo '\033[32m" + a1k + "\033[0m'\n", 150) +
+                    "for (i = 0; i < 1000; i++) {" +
+                    "echo '\033[32m" + a1k + "\033[0m'\n" +
+                    "}" +
                     "}";
                 final WorkflowJob project = story.j.jenkins.createProject(WorkflowJob.class, "canRenderLongOutputWhileBuildStillRunning");
                 project.setDefinition(new CpsFlowDefinition(script, true));
                 QueueTaskFuture<WorkflowRun> runFuture = project.scheduleBuild2(0);
                 assertNotNull(runFuture);
                 final WorkflowRun lastBuild = runFuture.waitForStart();
-                await().pollDelay(Duration.ofSeconds(10)).pollInterval(Duration.ofSeconds(5)).atMost(Duration.ofSeconds(60)).until(() -> {
+                await().pollInterval(Duration.ofSeconds(5)).atMost(Duration.ofSeconds(150)).until(() -> {
                     StringWriter writer = new StringWriter();
                     final int skipInitialStartAction = 3000;
                     assertTrue(lastBuild.getLogText().writeHtmlTo(skipInitialStartAction, writer) > 0);

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.ansicolor;
 
+import hudson.model.queue.QueueTaskFuture;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -13,13 +14,14 @@ import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.io.StringWriter;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.*;
 
 public class AnsiColorStepTest {
 
@@ -134,6 +136,33 @@ public class AnsiColorStepTest {
             ),
             script
         );
+    }
+
+    @Issue("200")
+    @Test
+    public void canRenderLongOutputWhileBuildStillRunning() {
+        story.addStep(new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                final String a1k = JenkinsTestSupport.repeat("a", 1024);
+                final String script = "ansiColor('xterm') {\n" +
+                    JenkinsTestSupport.repeat("echo '\033[32m" + a1k + "\033[0m'\n", 150) +
+                    "}";
+                final WorkflowJob project = story.j.jenkins.createProject(WorkflowJob.class, "canRenderLongOutputWhileBuildStillRunning");
+                project.setDefinition(new CpsFlowDefinition(script, true));
+                QueueTaskFuture<WorkflowRun> runFuture = project.scheduleBuild2(0);
+                assertNotNull(runFuture);
+                final WorkflowRun lastBuild = runFuture.waitForStart();
+                await().pollDelay(Duration.ofSeconds(10)).pollInterval(Duration.ofSeconds(5)).atMost(Duration.ofSeconds(60)).until(() -> {
+                    StringWriter writer = new StringWriter();
+                    final int skipInitialStartAction = 3000;
+                    assertTrue(lastBuild.getLogText().writeHtmlTo(skipInitialStartAction, writer) > 0);
+                    final String html = writer.toString().replaceAll("<!--.+?-->", "");
+                    return !runFuture.isDone() && html.contains("<span style=\"color: #00CD00;\">" + a1k + "</span>") && !html.contains("\033[32m");
+                });
+            }
+        });
     }
 
     private void assertOutputOnRunningPipeline(Collection<String> expectedOutput, Collection<String> notExpectedOutput, String pipelineScript) {

--- a/src/test/java/hudson/plugins/ansicolor/ColorConsoleAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/ColorConsoleAnnotatorTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.ansicolor;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,9 +12,11 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
+import java.io.File;
 import java.io.StringWriter;
 import java.util.logging.Level;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
+++ b/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
@@ -45,7 +45,7 @@ public class JenkinsTestSupport {
         });
     }
 
-    protected static String repeat(String s, int times) {
+    public static String repeat(String s, int times) {
         return IntStream.range(0, times).mapToObj(i -> s).collect(Collectors.joining());
     }
 }


### PR DESCRIPTION
Fixes #200 
All is pretty much described in the issue.
The PR adds a way for checking the currently active color map name in the currently running job run.