### PR TITLE
Remove tabular markup on new Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.7</version>
+    <version>4.15</version>
     <relativePath />
   </parent>
 
@@ -47,7 +47,7 @@
   <properties>
     <revision>0.7.4</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.204.1</jenkins.version>
+    <jenkins.version>2.204.6</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -117,7 +117,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.204.x</artifactId>
-        <version>11</version>
+        <version>18</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/global.jelly
+++ b/src/main/resources/hudson/plugins/ansicolor/AnsiColorBuildWrapper/global.jelly
@@ -1,13 +1,30 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-<f:section title="ANSI Color">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:d="jelly:define" xmlns:local="local">
+    <d:taglib uri="local">
+        <d:tag name="blockWrapper">
+            <j:choose>
+                <j:when test="${divBasedFormLayout}">
+                    <div>
+                        <d:invokeBody/>
+                    </div>
+                </j:when>
+                <j:otherwise>
+                    <table style="width:100%">
+                        <d:invokeBody/>
+                    </table>
+                </j:otherwise>
+            </j:choose>
+        </d:tag>
+    </d:taglib>
+
+    <f:section title="ANSI Color">
 	<f:entry title="${%Global color map for all builds}" field="globalColorMapName">
 		<f:textbox/>
 	</f:entry>
 	<f:advanced>
 	<f:entry title="Custom color maps">
 		<f:repeatable var="colorMap" items="${descriptor.colorMaps}" add="Add color map">
-			<table width="100%">
+			<local:blockWrapper>
 				<f:entry title="Name" field="name">
 					<f:textbox value="${colorMap.name}"/>
 				</f:entry>
@@ -54,7 +71,7 @@
 						<f:repeatableDeleteButton value="Delete"/>
 					</div>
 				</f:entry>
-			</table>
+            </local:blockWrapper>
 		</f:repeatable>
 	</f:entry>
 	</f:advanced>


### PR DESCRIPTION
Following https://www.jenkins.io/doc/developer/views/table-to-div-migration/

See https://www.jenkins.io/blog/2020/11/10/major-changes-in-weekly-releases/

I'm not sure if this is causing an issue but I'm working through all the plugins that appear with tabular markup in https://issues.jenkins.io/browse/JENKINS-64341

cc @tszmytka