### PR TITLE
Fixing jenkinsci#216: partial logs not showing colors

### DIFF
--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -89,6 +89,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
         switch (colorizedAction.getCommand()) {
             case START:
             case CURRENT:
+            case CONTINUE:
                 colorMapName = colorizedAction.getColorMapName();
                 break;
             case STOP:


### PR DESCRIPTION
I think this fixes #216. At least it does for my setup. But now the test hudson.plugins.ansicolor.ColorConsoleAnnotatorTest#testNoGlobalPipelineColorMap is failing and I do not fully understand about the mechanism behind. 

Problem seems to be a mixture of a missing pipeline step log line which could define the color map name in combination with partial / progressive output. Whenever there is no log line originated from a pipeline step rendered before the first ANSI escape sequence, the color map stays null and the log lines are not converted to (colorful) HTML. This often happens when a lot of colorful logs are written between to pipeline log lines or no pipeline log line at all. 

I thought it could be worth providing this PR even though the mentioned test is failing. I hope this can help to start a discussion and I can bring it towards a useful and sustainable fix.