### PR TITLE
Trigger tailed log output colorization also after Jenkins restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#219](https://github.com/jenkinsci/ansicolor-plugin/pull/219): Set env var TERM also if a default color map is used - [@tszmytka](https://github.com/tszmytka).
 * [#226](https://github.com/jenkinsci/ansicolor-plugin/pull/226): Work around withMaven step not passing on log line metadata - [@tszmytka](https://github.com/tszmytka).
 * [#225](https://github.com/jenkinsci/ansicolor-plugin/pull/225): Work around logstash-plugin hiding some log lines from ansicolor - [@tszmytka](https://github.com/tszmytka).
+* [#227](https://github.com/jenkinsci/ansicolor-plugin/pull/227): Trigger tailed log output colorization also after Jenkins restart - [@tszmytka](https://github.com/tszmytka).
 * Your contribution here.
 
 

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorBuildWrapperTest.java
@@ -10,7 +10,6 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.*;
 import org.junit.runner.RunWith;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.*;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mock;
@@ -34,6 +33,9 @@ import static org.mockito.Mockito.when;
 public class AnsiColorBuildWrapperTest {
     private static final String ESC = "\033";
     private static final String CLR = ESC + "[2K";
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
 
     @SuppressWarnings("unused")
     private enum CSI {
@@ -65,6 +67,12 @@ public class AnsiColorBuildWrapperTest {
         }
     }
 
+    @Rule
+    public RestartableJenkinsRule jenkinsRule = new RestartableJenkinsRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().recordPackage(ConsoleNote.class, Level.FINE).record(ColorConsoleAnnotator.class, Level.FINER);
+
     @Test
     public void testGetColorMapNameNull() {
         AnsiColorBuildWrapper instance = new AnsiColorBuildWrapper(null);
@@ -83,16 +91,9 @@ public class AnsiColorBuildWrapperTest {
         assertThat(ansiColorBuildWrapper, instanceOf(AnsiColorBuildWrapper.class));
     }
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule
-    public RestartableJenkinsRule story = new RestartableJenkinsRule();
-    @Rule
-    public LoggerRule logging = new LoggerRule().recordPackage(ConsoleNote.class, Level.FINE).record(ColorConsoleAnnotator.class, Level.FINER);
-
     @Test
     public void maven() {
-        story.then(r -> {
+        jenkinsRule.then(r -> {
             FreeStyleProject p = r.createFreeStyleProject();
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
             p.getBuildersList().add(new TestBuilder() {
@@ -130,7 +131,7 @@ public class AnsiColorBuildWrapperTest {
 
     @Test
     public void testMultilineEscapeSequence() {
-        story.then(r -> {
+        jenkinsRule.then(r -> {
             FreeStyleProject p = r.createFreeStyleProject();
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
             p.getBuildersList().add(new TestBuilder() {
@@ -161,7 +162,7 @@ public class AnsiColorBuildWrapperTest {
 
     @Test
     public void testDefaultForegroundBackground() {
-        story.then(r -> {
+        jenkinsRule.then(r -> {
             FreeStyleProject p = r.createFreeStyleProject();
             // The VGA ColorMap sets default foreground and background colors.
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper("vga"));
@@ -196,38 +197,34 @@ public class AnsiColorBuildWrapperTest {
     @Issue("JENKINS-54133")
     @Test
     public void testWorkflowWrap() {
-        story.addStep(new Statement() {
-
-            @Override
-            public void evaluate() throws Throwable {
-                Assume.assumeTrue(!Functions.isWindows());
-                story.j.createSlave();
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition(
-                    "node('!master') {\n"
-                        + "  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {\n"
-                        + "    sh(\"\"\"#!/bin/bash\n"
-                        + "      printf 'The following word is supposed to be \\\\e[31mred\\\\e[0m\\\\n'\"\"\"\n"
-                        + "    )\n"
-                        + "  }\n"
-                        + "}"
-                    , false
-                ));
-                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
-                String html = writer.toString();
-                assertTrue(
-                    "Failed to match color attribute in following HTML log output:\n" + html,
-                    html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*")
-                );
-            }
+        jenkinsRule.then(r -> {
+            Assume.assumeTrue(!Functions.isWindows());
+            jenkinsRule.j.createSlave();
+            WorkflowJob p = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                "node('!master') {\n"
+                    + "  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {\n"
+                    + "    sh(\"\"\"#!/bin/bash\n"
+                    + "      printf 'The following word is supposed to be \\\\e[31mred\\\\e[0m\\\\n'\"\"\"\n"
+                    + "    )\n"
+                    + "  }\n"
+                    + "}"
+                , false
+            ));
+            jenkinsRule.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
+            String html = writer.toString();
+            assertTrue(
+                "Failed to match color attribute in following HTML log output:\n" + html,
+                html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*")
+            );
         });
     }
 
     @Test
     public void testNonAscii() {
-        story.then(r -> {
+        jenkinsRule.then(r -> {
             FreeStyleProject p = r.createFreeStyleProject();
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
             p.getBuildersList().add(new TestBuilder() {
@@ -258,7 +255,7 @@ public class AnsiColorBuildWrapperTest {
     @Issue("JENKINS-55139")
     @Test
     public void testTerraform() {
-        story.then(r -> {
+        jenkinsRule.then(r -> {
             FreeStyleProject p = r.createFreeStyleProject();
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
             p.getBuildersList().add(new TestBuilder() {
@@ -291,7 +288,7 @@ public class AnsiColorBuildWrapperTest {
     @Issue("JENKINS-55139")
     @Test
     public void testRedundantResets() {
-        story.then(r -> {
+        jenkinsRule.then(r -> {
             FreeStyleProject p = r.createFreeStyleProject();
             p.getBuildWrappersList().add(new AnsiColorBuildWrapper(null));
             p.getBuildersList().add(new TestBuilder() {
@@ -480,7 +477,7 @@ public class AnsiColorBuildWrapperTest {
     }
 
     private void assertCorrectOutput(Collection<String> expectedOutput, Collection<String> notExpectedOutput, Consumer<PrintStream> inputProvider) {
-        story.then(r -> {
+        jenkinsRule.then(r -> {
             final String html = runBuildWithPlugin(r, inputProvider).replaceAll("<!--.+?-->", "");
             expectedOutput.forEach(s -> assertThat(html, containsString(s)));
             notExpectedOutput.forEach(s -> assertThat("Test failed for sequence: " + s.replace(ESC, "ESC"), html, not(containsString(s))));

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
@@ -13,16 +13,11 @@ import org.jenkinsci.plugins.workflow.steps.DynamicContext;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
-import org.mockito.Mockito;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.io.StringWriter;
 import java.time.Duration;
 import java.util.Arrays;
@@ -32,39 +27,36 @@ import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class AnsiColorStepTest {
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule
-    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    public RestartableJenkinsRule jenkinsRule = new RestartableJenkinsRule();
     @Rule
     public LoggerRule logging = new LoggerRule().record(ColorConsoleAnnotator.class, Level.FINER);
 
     @Test
     public void testPipelineStep() {
-        story.addStep(new Statement() {
-
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition(
-                    "ansiColor('xterm') {\n"
-                        + "  echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'\n"
-                        + " echo \"TERM=${env.TERM}\""
-                        + "}"
-                    , true));
-                WorkflowRun run = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
-                String html = writer.toString();
-                story.j.assertLogContains("TERM=xterm", run);
-                assertTrue(
-                    "Failed to match color attribute in following HTML log output:\n" + html,
-                    html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*")
-                );
-            }
+        jenkinsRule.then(r -> {
+            WorkflowJob p = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                "ansiColor('xterm') {\n"
+                    + "  echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'\n"
+                    + " echo \"TERM=${env.TERM}\""
+                    + "}"
+                , true));
+            WorkflowRun run = jenkinsRule.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
+            String html = writer.toString();
+            jenkinsRule.j.assertLogContains("TERM=xterm", run);
+            assertTrue(
+                "Failed to match color attribute in following HTML log output:\n" + html,
+                html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*")
+            );
         });
     }
 
@@ -136,29 +128,25 @@ public class AnsiColorStepTest {
     @Issue("200")
     @Test
     public void canRenderLongOutputWhileBuildStillRunning() {
-        story.addStep(new Statement() {
-
-            @Override
-            public void evaluate() throws Throwable {
-                final String a1k = JenkinsTestSupport.repeat("a", 1024);
-                final String script = "ansiColor('xterm') {\n" +
-                    "for (i = 0; i < 1000; i++) {" +
-                    "echo '\033[32m" + a1k + "\033[0m'\n" +
-                    "}" +
-                    "}";
-                final WorkflowJob project = story.j.jenkins.createProject(WorkflowJob.class, "canRenderLongOutputWhileBuildStillRunning");
-                project.setDefinition(new CpsFlowDefinition(script, true));
-                QueueTaskFuture<WorkflowRun> runFuture = project.scheduleBuild2(0);
-                assertNotNull(runFuture);
-                final WorkflowRun lastBuild = runFuture.waitForStart();
-                await().pollInterval(Duration.ofSeconds(5)).atMost(Duration.ofSeconds(150)).until(() -> {
-                    StringWriter writer = new StringWriter();
-                    final int skipInitialStartAction = 3000;
-                    assertTrue(lastBuild.getLogText().writeHtmlTo(skipInitialStartAction, writer) > 0);
-                    final String html = writer.toString().replaceAll("<!--.+?-->", "");
-                    return !runFuture.isDone() && html.contains("<span style=\"color: #00CD00;\">" + a1k + "</span>") && !html.contains("\033[32m");
-                });
-            }
+        jenkinsRule.then(r -> {
+            final String a1k = JenkinsTestSupport.repeat("a", 1024);
+            final String script = "ansiColor('xterm') {\n" +
+                "for (i = 0; i < 1000; i++) {" +
+                "echo '\033[32m" + a1k + "\033[0m'\n" +
+                "}" +
+                "}";
+            final WorkflowJob project = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "canRenderLongOutputWhileBuildStillRunning");
+            project.setDefinition(new CpsFlowDefinition(script, true));
+            QueueTaskFuture<WorkflowRun> runFuture = project.scheduleBuild2(0);
+            assertNotNull(runFuture);
+            final WorkflowRun lastBuild = runFuture.waitForStart();
+            await().pollInterval(Duration.ofSeconds(5)).atMost(Duration.ofSeconds(150)).until(() -> {
+                StringWriter writer = new StringWriter();
+                final int skipInitialStartAction = 3000;
+                assertTrue(lastBuild.getLogText().writeHtmlTo(skipInitialStartAction, writer) > 0);
+                final String html = writer.toString().replaceAll("<!--.+?-->", "");
+                return !runFuture.isDone() && html.contains("<span style=\"color: #00CD00;\">" + a1k + "</span>") && !html.contains("\033[32m");
+            });
         });
     }
 
@@ -190,21 +178,17 @@ public class AnsiColorStepTest {
             "\033[33mYellow words, white background.",
             "TERM=null"
         );
-        story.addStep(new Statement() {
+        jenkinsRule.then(r -> {
+            Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName(globalColorMapName);
 
-            @Override
-            public void evaluate() throws Throwable {
-                Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName(globalColorMapName);
-
-                final WorkflowJob project = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                project.setDefinition(new CpsFlowDefinition(script, true));
-                story.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
-                final String html = writer.toString().replaceAll("<!--.+?-->", "");
-                assertThat(html).contains(expectedOutput);
-                assertThat(html).doesNotContain(notExpectedOutput);
-            }
+            final WorkflowJob project = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "p");
+            project.setDefinition(new CpsFlowDefinition(script, true));
+            jenkinsRule.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
+            final String html = writer.toString().replaceAll("<!--.+?-->", "");
+            assertThat(html).contains(expectedOutput);
+            assertThat(html).doesNotContain(notExpectedOutput);
         });
     }
 
@@ -229,42 +213,34 @@ public class AnsiColorStepTest {
     }
 
     private void assertOutputOnRunningPipeline(Collection<String> expectedOutput, Collection<String> notExpectedOutput, String pipelineScript) {
-        story.addStep(new Statement() {
-
-            @Override
-            public void evaluate() throws Throwable {
-                final WorkflowJob project = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                project.setDefinition(new CpsFlowDefinition(pipelineScript, true));
-                story.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
-                final String html = writer.toString().replaceAll("<!--.+?-->", "");
-                assertThat(html).contains(expectedOutput);
-                assertThat(html).doesNotContain(notExpectedOutput);
-            }
+        jenkinsRule.then(r -> {
+            final WorkflowJob project = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "p");
+            project.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+            jenkinsRule.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
+            final String html = writer.toString().replaceAll("<!--.+?-->", "");
+            assertThat(html).contains(expectedOutput);
+            assertThat(html).doesNotContain(notExpectedOutput);
         });
     }
 
     private void assertNlsOnRunningPipeline() {
-        story.addStep(new Statement() {
-
-            @Override
-            public void evaluate() throws Throwable {
-                final String script = "ansiColor('xterm') {\n" +
-                    "echo '\033[34mHello\033[0m \033[33mcolorful\033[0m \033[35mworld!\033[0m'" +
-                    "}";
-                final WorkflowJob project = story.j.jenkins.createProject(WorkflowJob.class, "willPrintAdditionalNlOnKubernetesPlugin");
-                project.setDefinition(new CpsFlowDefinition(script, true));
-                story.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
-                final String html = writer.toString().replaceAll("<!--.+?-->", "")
-                    .replaceAll("</span>", "")
-                    .replaceAll("<span.+?>", "")
-                    .replaceAll("<div.+?/div>", "");
-                final String nl = System.lineSeparator();
-                assertThat(html).contains("ansiColor" + nl + "[Pipeline] {" + nl + nl).contains("[Pipeline] }" + nl + nl + "[Pipeline] // ansiColor");
-            }
+        jenkinsRule.then(r -> {
+            final String script = "ansiColor('xterm') {\n" +
+                "echo '\033[34mHello\033[0m \033[33mcolorful\033[0m \033[35mworld!\033[0m'" +
+                "}";
+            final WorkflowJob project = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "willPrintAdditionalNlOnKubernetesPlugin");
+            project.setDefinition(new CpsFlowDefinition(script, true));
+            jenkinsRule.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
+            final String html = writer.toString().replaceAll("<!--.+?-->", "")
+                .replaceAll("</span>", "")
+                .replaceAll("<span.+?>", "")
+                .replaceAll("<div.+?/div>", "");
+            final String nl = System.lineSeparator();
+            assertThat(html).contains("ansiColor" + nl + "[Pipeline] {" + nl + nl).contains("[Pipeline] }" + nl + nl + "[Pipeline] // ansiColor");
         });
     }
 }

--- a/src/test/java/hudson/plugins/ansicolor/ColorConsoleAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/ColorConsoleAnnotatorTest.java
@@ -3,72 +3,60 @@ package hudson.plugins.ansicolor;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
-import java.io.File;
 import java.io.StringWriter;
 import java.util.logging.Level;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ColorConsoleAnnotatorTest {
-
-    public ColorConsoleAnnotatorTest() {
-    }
-
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
+
     @Rule
-    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    public RestartableJenkinsRule jenkinsRule = new RestartableJenkinsRule();
+
     @Rule
     public LoggerRule logging = new LoggerRule().record(ColorConsoleAnnotator.class, Level.FINER);
 
     @Test
     public void testGlobalPipelineColorMap() {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName("xterm");
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition(
-                                "echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'"
-                        , true));
-                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
-                String html = writer.toString();
-                assertTrue("Failed to match color attribute in following HTML log output:\n" + html,
-                        html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
-            }
+        jenkinsRule.then(r -> {
+            Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName("xterm");
+            WorkflowJob p = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'", true));
+            jenkinsRule.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
+            String html = writer.toString();
+            assertTrue(
+                "Failed to match color attribute in following HTML log output:\n" + html,
+                html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*")
+            );
         });
     }
 
     @Test
     public void testNoGlobalPipelineColorMap() {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName(null);
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition(
-                                "echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'"
-                        , true));
-                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
-                String html = writer.toString();
-                assertFalse("Color attribute was applied in following HTML log output even though the color map was not globally enabled:\n" + html,
-                        html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*"));
-            }
+        jenkinsRule.then(r -> {
+            Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).setGlobalColorMapName(null);
+            WorkflowJob p = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("echo 'The following word is supposed to be \\u001B[31mred\\u001B[0m'", true));
+            jenkinsRule.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            assertTrue(p.getLastBuild().getLogText().writeHtmlTo(0L, writer) > 0);
+            String html = writer.toString();
+            assertFalse(
+                "Color attribute was applied in following HTML log output even though the color map was not globally enabled:\n" + html,
+                html.replaceAll("<!--.+?-->", "").matches("(?s).*<span style=\"color: #CD0000;\">red</span>.*")
+            );
         });
     }
 }

--- a/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
+++ b/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
@@ -20,9 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class JenkinsTestSupport {
+    private static final int CONSOLE_TAIL_DEFAULT = 150;
+
     @Rule
     public RestartableJenkinsRule jenkinsRule = new RestartableJenkinsRule();
-    private static final int CONSOLE_TAIL_DEFAULT = 150;
 
     protected void assertOutputOnRunningPipeline(
         BooleanSupplier assumption,

--- a/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
+++ b/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
@@ -5,7 +5,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Assume;
 import org.junit.Rule;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.io.File;
@@ -25,7 +24,14 @@ public class JenkinsTestSupport {
     public RestartableJenkinsRule jenkinsRule = new RestartableJenkinsRule();
     private static final int CONSOLE_TAIL_DEFAULT = 150;
 
-    protected void assertOutputOnRunningPipeline(BooleanSupplier assumption, String expectedOutput, String notExpectedOutput, String pipelineScript, boolean useShortLog, Map<String, String> properties) {
+    protected void assertOutputOnRunningPipeline(
+        BooleanSupplier assumption,
+        String expectedOutput,
+        String notExpectedOutput,
+        String pipelineScript,
+        boolean useShortLog,
+        Map<String, String> properties
+    ) {
         assertOutputOnRunningPipeline(assumption, Collections.singletonList(expectedOutput), Collections.singletonList(notExpectedOutput), pipelineScript, useShortLog, properties);
     }
 
@@ -45,24 +51,20 @@ public class JenkinsTestSupport {
         boolean useShortLog,
         Map<String, String> properties
     ) {
-        jenkinsRule.addStep(new Statement() {
-
-            @Override
-            public void evaluate() throws Throwable {
-                Assume.assumeTrue(assumption.getAsBoolean());
-                properties.forEach(System::setProperty);
-                final WorkflowJob project = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "test-project-" + JenkinsTestSupport.this.getClass().getSimpleName());
-                project.setDefinition(new CpsFlowDefinition(pipelineScript, true));
-                jenkinsRule.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
-                StringWriter writer = new StringWriter();
-                final WorkflowRun lastBuild = project.getLastBuild();
-                final long start = useShortLog ? new File(lastBuild.getRootDir(), "log").length() - CONSOLE_TAIL_DEFAULT * 1024 : 0;
-                assertTrue(lastBuild.getLogText().writeHtmlTo(start, writer) > 0);
-                properties.keySet().forEach(System::clearProperty);
-                final String html = writer.toString().replaceAll("<!--.+?-->", "");
-                assertThat(html).contains(expectedOutput);
-                assertThat(html).doesNotContain(notExpectedOutput);
-            }
+        jenkinsRule.then(r -> {
+            Assume.assumeTrue(assumption.getAsBoolean());
+            properties.forEach(System::setProperty);
+            final WorkflowJob project = jenkinsRule.j.jenkins.createProject(WorkflowJob.class, "test-project-" + JenkinsTestSupport.this.getClass().getSimpleName());
+            project.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+            jenkinsRule.j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+            StringWriter writer = new StringWriter();
+            final WorkflowRun lastBuild = project.getLastBuild();
+            final long start = useShortLog ? new File(lastBuild.getRootDir(), "log").length() - CONSOLE_TAIL_DEFAULT * 1024 : 0;
+            assertTrue(lastBuild.getLogText().writeHtmlTo(start, writer) > 0);
+            properties.keySet().forEach(System::clearProperty);
+            final String html = writer.toString().replaceAll("<!--.+?-->", "");
+            assertThat(html).contains(expectedOutput);
+            assertThat(html).doesNotContain(notExpectedOutput);
         });
     }
 

--- a/src/test/java/hudson/plugins/ansicolor/action/ShortlogActionCreatorIntegrationTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/action/ShortlogActionCreatorIntegrationTest.java
@@ -40,8 +40,8 @@ public class ShortlogActionCreatorIntegrationTest extends JenkinsTestSupport {
         final Map<String, String> properties = new HashMap<>();
         properties.put(ShortlogActionCreator.PROP_LINES_WHOLE, "true");
         BooleanSupplier wholeLinesJenkins = () -> Optional.ofNullable(Jenkins.getVersion())
-        .orElse(ShortlogActionCreator.LINES_WHOLE_SINCE_VERSION)
-        .isNewerThan(ShortlogActionCreator.LINES_WHOLE_SINCE_VERSION);
+            .orElse(ShortlogActionCreator.LINES_WHOLE_SINCE_VERSION)
+            .isNewerThan(ShortlogActionCreator.LINES_WHOLE_SINCE_VERSION);
         assertOutputOnRunningPipeline(wholeLinesJenkins, "<span style=\"color: #00CD00;\">" + AS_1K + "</span>", "\033", script, true, properties);
     }
 

--- a/src/test/java/hudson/plugins/ansicolor/action/ShortlogActionCreatorTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/action/ShortlogActionCreatorTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.ansicolor.action;
 
 import hudson.console.ConsoleNote;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
+import java.net.URL;
 import java.util.HashMap;
 
 import static org.junit.Assert.*;
@@ -66,14 +68,16 @@ public class ShortlogActionCreatorTest {
         final String serializedNote = "<mock-serialized-note-start>";
         when(lineIdentifier.hash(eq(shortlogLine), eq(1L))).thenReturn(lineHash);
 
-        final File file = new File(getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), logFile)).getFile());
+        final URL inputFile = getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), logFile));
+        Assume.assumeNotNull(inputFile);
+        final File file = new File(inputFile.getFile());
         final HashMap<String, ColorizedAction> startActions = new HashMap<>();
         startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-start0>", new ColorizedAction("css", ColorizedAction.Command.START));
         startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-stop0>", new ColorizedAction("css", ColorizedAction.Command.STOP));
         startActions.put(ConsoleNote.PREAMBLE_STR + serializedNote, colorizedAction);
         startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-stop>", new ColorizedAction("xterm", ColorizedAction.Command.STOP));
         startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-start1>", new ColorizedAction("gnome-terminal", ColorizedAction.Command.START));
-        final ColorizedAction shortlogAction = shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole);
+        final ColorizedAction shortlogAction = shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole, 0);
         assertEquals(colorizedAction.getColorMapName(), shortlogAction.getColorMapName());
         assertEquals(colorizedAction.getCommand(), shortlogAction.getCommand());
         assertNotEquals(colorizedAction.getId(), shortlogAction.getId());
@@ -86,11 +90,13 @@ public class ShortlogActionCreatorTest {
         for (boolean keepLinesWhole : keepLinesWholeOptions) {
             final String serializedNote = "<mock-serialized-note-start>";
             final ColorizedAction colorizedAction = new ColorizedAction("xterm", ColorizedAction.Command.START);
-            final File file = new File(getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog.log")).getFile());
+            final URL inputFile = getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog.log"));
+            Assume.assumeNotNull(inputFile);
+            final File file = new File(inputFile.getFile());
             final HashMap<String, ColorizedAction> startActions = new HashMap<>();
             startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-start0>", new ColorizedAction("css", ColorizedAction.Command.START));
             startActions.put(ConsoleNote.PREAMBLE_STR + serializedNote, colorizedAction);
-            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 256, keepLinesWhole));
+            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 256, keepLinesWhole, 0));
             verify(lineIdentifier, never()).hash(anyString(), anyLong());
         }
     }
@@ -99,8 +105,10 @@ public class ShortlogActionCreatorTest {
     public void wontCreateActionIfBuildHasNoStartActions() {
         final boolean[] keepLinesWholeOptions = {true, false};
         for (boolean keepLinesWhole : keepLinesWholeOptions) {
-            final File file = new File(getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog.log")).getFile());
-            assertNull(shortlogActionCreator.createActionForShortlog(file, new HashMap<>(), 3, keepLinesWhole));
+            final URL inputFile = getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog.log"));
+            Assume.assumeNotNull(inputFile);
+            final File file = new File(inputFile.getFile());
+            assertNull(shortlogActionCreator.createActionForShortlog(file, new HashMap<>(), 3, keepLinesWhole, 0));
             verify(lineIdentifier, never()).hash(anyString(), anyLong());
         }
     }
@@ -112,8 +120,10 @@ public class ShortlogActionCreatorTest {
             final HashMap<String, ColorizedAction> startActions = new HashMap<>();
             startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-start0>", new ColorizedAction("css", ColorizedAction.Command.START));
             startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-stop0>", new ColorizedAction("css", ColorizedAction.Command.STOP));
-            final File file = new File(getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog-no-notes.log")).getFile());
-            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole));
+            final URL inputFile = getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog-no-notes.log"));
+            Assume.assumeNotNull(inputFile);
+            final File file = new File(inputFile.getFile());
+            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole, 0));
             verify(lineIdentifier, never()).hash(anyString(), anyLong());
         }
     }
@@ -125,7 +135,7 @@ public class ShortlogActionCreatorTest {
             final HashMap<String, ColorizedAction> startActions = new HashMap<>();
             startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-start0>", new ColorizedAction("css", ColorizedAction.Command.START));
             final File file = new File("non-existing.log");
-            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole));
+            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole, 0));
             verify(lineIdentifier, never()).hash(anyString(), anyLong());
         }
     }
@@ -134,12 +144,14 @@ public class ShortlogActionCreatorTest {
     public void wontCreateActionIfActionIsNotActiveAtShortlogLimit() {
         final boolean[] keepLinesWholeOptions = {true, false};
         for (boolean keepLinesWhole : keepLinesWholeOptions) {
-            final File file = new File(getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog-action-not-active.log")).getFile());
+            final URL inputFile = getClass().getResource(String.join("/", "", getClass().getName().replace('.', '/'), "testlog-action-not-active.log"));
+            Assume.assumeNotNull(inputFile);
+            final File file = new File(inputFile.getFile());
             final HashMap<String, ColorizedAction> startActions = new HashMap<>();
             startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-start>", new ColorizedAction("css", ColorizedAction.Command.START));
             startActions.put(ConsoleNote.PREAMBLE_STR + "<mock-serialized-note-stop>", new ColorizedAction("css", ColorizedAction.Command.STOP));
 
-            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole));
+            assertNull(shortlogActionCreator.createActionForShortlog(file, startActions, 3, keepLinesWhole, 0));
             verify(lineIdentifier, never()).hash(anyString(), anyLong());
         }
     }


### PR DESCRIPTION
Currently the functionality allowing tailed log output to be colorized is executed at the very end of a build - after the log file has already been closed (`onFinalized`). This permits accurate calculation of the point where tailed output will begin and correct `ColorizedAction.Command.START` action injection. Upon rendering, the new action gets added to the output but since the log file has already been closed the new content is not persisted. As a result tailed log output looks fine until a Jenkins instance gets rebooted. After the restart it gets shown without any ansi code interpreted (full output is fine before and after reboot).

The PR fixes this by moving the execution a bit earlier - to `onCompleted`. This point in the lifecycle of a `WorkflowRun` happens before log file has been closed so any log amendments get properly persisted and tailed log output gets correctly rendered before and after Jenkins restart. One drawback is that one final line gets added to the log *after* `onCompleted` so tailed output begin calculation needs to take that into consideration.
This change _might_ also work for #216 but I can't be 100% sure as I haven't been able to reproduce that issue.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
