### PR TITLE
Fix link for CHANGELOG

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Document any external behavior in the [README](README.md).
 
 #### Update Changelog
 
-Add a line to [CHANGELOG](CHANGELOG.md) under *Next Release*. Make it look like every other line, including your name and link to your Github account.
+Add a line to [CHANGELOG](../CHANGELOG.md) under *Next Release*. Make it look like every other line, including your name and link to your Github account.
 
 #### Commit Changes
 
@@ -89,7 +89,7 @@ git push origin my-feature-branch -f
 
 #### Update CHANGELOG Again
 
-Update the [CHANGELOG](CHANGELOG.md) with the pull request number. A typical entry looks as follows.
+Update the [CHANGELOG](../CHANGELOG.md) with the pull request number. A typical entry looks as follows.
 
 ```
 * [#123](https://github.com/jenkinsci/ansicolor-plugin/pull/123): Reticulated splines - [@contributor](https://github.com/contributor).


### PR DESCRIPTION
This PR fixes the broken link in `CONTRIBUTING.md` file in this project.

**Fixes** #231

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
