### PR TITLE
chore(doc/contributing): replace the deprecated Wiki tutorial link by the jenkins.io doc one

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ You're encouraged to submit [pull requests](https://github.com/jenkinsci/ansicol
 
 #### Writing Jenkins Plugins
 
-Before you begin, check out the [Jenkins-CI Plugin Tutorial](https://wiki.jenkins-ci.org/display/JENKINS/Plugin+tutorial).
+Before you begin, check out the [Jenkins Plugin Tutorial](https://www.jenkins.io/doc/developer/tutorial/).
 
 #### Fork the Project
 


### PR DESCRIPTION
This PR updates the Jenkins plugin tutorial link.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
