### PR TITLE
Remove AssertJ for Java 21 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.24.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>4.2.0</version>

--- a/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
+++ b/src/test/java/hudson/plugins/ansicolor/AnsiColorStepTest.java
@@ -28,8 +28,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -205,8 +208,12 @@ public class AnsiColorStepTest {
             StringWriter writer = new StringWriter();
             assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
             final String html = writer.toString().replaceAll("<!--.+?-->", "");
-            assertThat(html).contains(expectedOutput);
-            assertThat(html).doesNotContain(notExpectedOutput);
+            for (String expected : expectedOutput) {
+                assertThat(html, containsString(expected));
+            }
+            for (String notExpected : notExpectedOutput) {
+                assertThat(html, not(containsString(notExpected)));
+            }
         });
     }
 
@@ -235,7 +242,7 @@ public class AnsiColorStepTest {
     public void canGetConstructorParametersForSnippetGenerator() {
         final String colorMapName = AnsiColorMap.VGA.getName();
         final AnsiColorStep step = new AnsiColorStep(colorMapName);
-        assertThat(step.getColorMapName()).isEqualTo(colorMapName);
+        assertEquals(colorMapName, step.getColorMapName());
     }
 
     private void assertOutputOnRunningPipeline(Collection<String> expectedOutput, Collection<String> notExpectedOutput, String pipelineScript) {
@@ -246,8 +253,12 @@ public class AnsiColorStepTest {
             StringWriter writer = new StringWriter();
             assertTrue(project.getLastBuild().getLogText().writeHtmlTo(0, writer) > 0);
             final String html = writer.toString().replaceAll("<!--.+?-->", "");
-            assertThat(html).contains(expectedOutput);
-            assertThat(html).doesNotContain(notExpectedOutput);
+            for (String expected : expectedOutput) {
+                assertThat(html, containsString(expected));
+            }
+            for (String notExpected : notExpectedOutput) {
+                assertThat(html, not(containsString(notExpected)));
+            }
         });
     }
 
@@ -266,7 +277,8 @@ public class AnsiColorStepTest {
                 .replaceAll("<span.+?>", "")
                 .replaceAll("<div.+?/div>", "");
             final String nl = System.lineSeparator();
-            assertThat(html).contains("ansiColor" + nl + "[Pipeline] {" + nl + nl).contains("[Pipeline] }" + nl + nl + "[Pipeline] // ansiColor");
+            assertThat(html, containsString("ansiColor" + nl + "[Pipeline] {" + nl + nl));
+            assertThat(html, containsString("[Pipeline] }" + nl + nl + "[Pipeline] // ansiColor"));
         });
     }
 }

--- a/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
+++ b/src/test/java/hudson/plugins/ansicolor/JenkinsTestSupport.java
@@ -16,7 +16,9 @@ import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 
 public class JenkinsTestSupport {
@@ -64,8 +66,12 @@ public class JenkinsTestSupport {
             assertTrue(lastBuild.getLogText().writeHtmlTo(start, writer) > 0);
             properties.keySet().forEach(System::clearProperty);
             final String html = writer.toString().replaceAll("<!--.+?-->", "");
-            assertThat(html).contains(expectedOutput);
-            assertThat(html).doesNotContain(notExpectedOutput);
+            for (String expected : expectedOutput) {
+                assertThat(html, containsString(expected));
+            }
+            for (String notExpected : notExpectedOutput) {
+                assertThat(html, not(containsString(notExpected)));
+            }
         });
     }
 


### PR DESCRIPTION
Remove AssertJ which does not currently support Java 21. This also makes the test framework used in this plugin consistent with the test framework used in other Jenkins plugins and Jenkins core.

### Testing done

Ran the tests on Java 21 before and after this PR. The tests failed before and passed after.