### PR TITLE
Use `java.io` `nullOutputstream` instead of deprecated alternatives

### DIFF
--- a/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
+++ b/src/main/java/hudson/plugins/ansicolor/AnsiHtmlOutputStream.java
@@ -26,7 +26,6 @@ package hudson.plugins.ansicolor;
 import static hudson.plugins.ansicolor.AnsiAttributeElement.AnsiAttrType;
 
 import hudson.console.ConsoleNote;
-import hudson.util.NullStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -101,7 +100,7 @@ public class AnsiHtmlOutputStream extends AnsiOutputStream {
      * Both the start- and stop-Method are idempotent and may be called regardless of current concealing state.
      */
     private void startConcealing() {
-        this.out = new NullStream();
+        this.out = OutputStream.nullOutputStream();
     }
 
     private void stopConcealing() {

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -34,7 +34,6 @@ import hudson.plugins.ansicolor.action.ColorizedAction;
 import hudson.plugins.ansicolor.action.LineIdentifier;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.output.CountingOutputStream;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -42,6 +41,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -109,7 +109,7 @@ final class ColorConsoleAnnotator extends ConsoleAnnotator<Object> {
         List<AnsiAttributeElement> nextOpenTags = openTags;
         AnsiColorMap colorMap = Jenkins.get().getDescriptorByType(AnsiColorBuildWrapper.DescriptorImpl.class).getColorMap(colorMapName);
         if (s.indexOf('\u001B') != -1 || !openTags.isEmpty() || colorMap.getDefaultBackground() != null || colorMap.getDefaultForeground() != null) {
-            CountingOutputStream outgoing = new CountingOutputStream(new NullOutputStream());
+            CountingOutputStream outgoing = new CountingOutputStream(OutputStream.nullOutputStream());
             class EmitterImpl implements AnsiAttributeElement.Emitter {
                 CountingOutputStream incoming;
                 int adjustment;


### PR DESCRIPTION
Use `java.io` `nullOutputstream` instead of deprecated alternatives

### Testing done

I just let a `mvn test  run locally

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
