### PR TITLE
Add usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and has [a page](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin) o
 ```
 java -jar jenkins-cli.jar install-plugin ansicolor
 ```
-## Use
+## Enable and Usage
 
 After installing the AnsiColor plugin:
 
@@ -31,7 +31,7 @@ After installing the AnsiColor plugin:
 
 This will display colored console output correctly.
 
-# Enable
+
 
 ## In a Pipeline
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ and has [a page](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin) o
 ```
 java -jar jenkins-cli.jar install-plugin ansicolor
 ```
+## Use
+
+After installing the AnsiColor plugin:
+
+1. Go to your Jenkins job configuration.
+2. In "Build Environment", enable **Color ANSI Console Output**.
+3. Choose an ANSI color map (e.g., xterm).
+4. Save and run the job.
+
+This will display colored console output correctly.
+
 # Enable
 
 ## In a Pipeline
@@ -171,13 +182,3 @@ The ANSI Color Plugin is licensed under the MIT License.
 
 It uses [JANSI](https://github.com/fusesource/jansi/) (Apache 2.0 License).
 
-## Usage
-
-After installing the AnsiColor plugin:
-
-1. Go to your Jenkins job configuration.
-2. In "Build Environment", enable **Color ANSI Console Output**.
-3. Choose an ANSI color map (e.g., xterm).
-4. Save and run the job.
-
-This will display colored console output correctly.

--- a/README.md
+++ b/README.md
@@ -170,3 +170,14 @@ RSpec formatters detect whether RSpec is running in a terminal or not, therefore
 The ANSI Color Plugin is licensed under the MIT License.
 
 It uses [JANSI](https://github.com/fusesource/jansi/) (Apache 2.0 License).
+
+## Usage
+
+After installing the AnsiColor plugin:
+
+1. Go to your Jenkins job configuration.
+2. In "Build Environment", enable **Color ANSI Console Output**.
+3. Choose an ANSI color map (e.g., xterm).
+4. Save and run the job.
+
+This will display colored console output correctly.


### PR DESCRIPTION
Added a basic usage section to the README to help beginners understand how to use the AnsiColor plugin.
This improves documentation clarity for new users.