### PR TITLE
Migrate StringEscapeUtils to Commons Text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.2099.v68c2f5e27299</version>
+    <version>6.2211.v27f680c93c53</version>
     <relativePath />
   </parent>
 
@@ -49,6 +49,7 @@
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
   </properties>
 
@@ -65,6 +66,10 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>

--- a/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/ansicolor/ColorConsoleAnnotator.java
@@ -34,7 +34,7 @@ import hudson.plugins.ansicolor.action.ColorizedAction;
 import hudson.plugins.ansicolor.action.LineIdentifier;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.output.CountingOutputStream;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 


### PR DESCRIPTION
`StringEscapeUtils` has no Java Platform equivalent, so this moves it to Commons Text via the `commons-text-api` plugin.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404, jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory (GHSA-j288-q9x7-2f5v).

jenkinsci/ansicolor-plugin#353 migrated this plugin to native Java, but missed `ColorConsoleAnnotator.java:37`, which still imported `org.apache.commons.lang.StringEscapeUtils`. It is the plugin's last Commons Lang 2 usage — a `usage-in-plugins` scan of all published plugins on 2026-08-08 confirms the released `536.v13fa_b_860c267` still references it.

## What's changed

- `StringEscapeUtils.escapeJava` (2 call sites, both in one `LOGGER.finer` statement) moves to `org.apache.commons.text.StringEscapeUtils`, adding the versionless `io.jenkins.plugins:commons-text-api` dependency. Deliberately **not** `org.apache.commons.lang3.StringEscapeUtils`, which is deprecated.
- Parent POM `5.2099.v68c2f5e27299` → `6.2211.v27f680c93c53`, needed for the enforcer rule below. The baseline is already `2.504.3`, so this is within the 6.x requirements.
- Enabled `<ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>` to prevent a regression.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS — 115 tests, 0 failures, 0 errors, 3 skipped.

The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an `org.apache.commons.lang.*` import comes back. I verified it is genuinely active rather than silently skipping: restoring the old import with the property in place fails the build with `Reason: Use Commons Lang 2 (org.apache.commons.lang.*)`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
